### PR TITLE
fix(ci): update ty test suppressions

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,7 +88,7 @@ def test_meeting_with_start_time() -> None:
 
 def test_meeting_invalid_day() -> None:
     with pytest.raises(ValidationError):
-        Meeting(day="SAT", duration=50)  # type: ignore[arg-type]
+        Meeting(day="SAT", duration=50)  # type: ignore[invalid-argument-type]
 
 
 def test_class_pattern_valid() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -187,4 +187,4 @@ def test_time_point_serializer_roundtrip() -> None:
 
 def test_models_reject_extra_fields() -> None:
     with pytest.raises(ValidationError):
-        Duration(duration=1, extra=2)  # type: ignore[call-arg]
+        Duration(duration=1, extra=2)  # type: ignore[unknown-argument]


### PR DESCRIPTION
## Summary

Update the two type-ignore codes in invalid-input tests to match diagnostics emitted by the current `ty` checker.

## Root cause

The dependency-update PR upgrades `ty`, whose diagnostic names differ from the historical suppressions.

## Validation

- `uv run prek run --all-files`
- `uv run pytest` (121 passed)