### PR TITLE
fix(ci): resolve ty 0.0.51 diagnostics

### DIFF
--- a/src/scheduler/server.py
+++ b/src/scheduler/server.py
@@ -599,7 +599,7 @@ async def get_schedule_details(schedule_id: str):
 
 
 @app.post("/schedules/{schedule_id}/next", response_model=ScheduleResponse)
-async def get_next_schedule(schedule_id: str):
+async def get_next_schedule(schedule_id: str) -> ScheduleResponse:
     """
     Get the next generated schedule.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,7 +88,7 @@ def test_meeting_with_start_time() -> None:
 
 def test_meeting_invalid_day() -> None:
     with pytest.raises(ValidationError):
-        Meeting(day="SAT", duration=50)  # type: ignore[invalid-argument-type]
+        Meeting.model_validate({"day": "SAT", "duration": 50})
 
 
 def test_class_pattern_valid() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -233,7 +233,7 @@ def test_server_cleanup_unknown_session_no_crash(client: TestClient) -> None:
 def test_server_serializes_concurrent_next_requests(minimal_combined_config: CombinedConfig) -> None:
     config = minimal_combined_config.model_copy(update={"limit": 2})
 
-    async def generate_two() -> list[object]:
+    async def generate_two() -> tuple[ScheduleResponse | BaseException, ScheduleResponse | BaseException]:
         submitted = await submit_schedule(config)
         try:
             return await asyncio.gather(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -187,4 +187,4 @@ def test_time_point_serializer_roundtrip() -> None:
 
 def test_models_reject_extra_fields() -> None:
     with pytest.raises(ValidationError):
-        Duration(duration=1, extra=2)  # type: ignore[unknown-argument]
+        Duration.model_validate({"duration": 1, "extra": 2})


### PR DESCRIPTION
## Summary

Make the test cases type-correct under `ty` 0.0.51 without suppressions.

- Validate malformed Pydantic payloads through `model_validate`.
- Annotate the next-schedule endpoint response.
- Match the concurrent helper return type to `asyncio.gather(..., return_exceptions=True)`.

## Root cause

The dependency update raises `ty` from 0.0.24 to 0.0.51, which detects invalid test construction and a mismatched async return type.

## Validation

- `uvx --from ty==0.0.51 ty check`
- `uv run prek run --all-files`
- `uv run pytest` (121 passed)