### PR TITLE
docs: restore implementation parity

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,6 +73,12 @@ jobs:
           grep -Fq "class scheduler.config.CombinedConfig" fern/static/python-reference/scheduler-python/scheduler/config.mdx
           grep -Fq "class scheduler.models.course.CourseInstance" fern/static/python-reference/scheduler-python/scheduler/models/course.mdx
           grep -Fq "class scheduler.contracts.ScheduleDiagnosis" fern/static/python-reference/scheduler-python/scheduler/contracts.mdx
+          grep -Fq "Scheduler.diagnose" fern/static/python-reference/scheduler-python/scheduler/scheduler.mdx
+          grep -Fq "Scheduler.audit_schedule" fern/static/python-reference/scheduler-python/scheduler/scheduler.mdx
+          grep -Fq "validate_combined_config_data" fern/static/python-reference/scheduler-python/scheduler/configuration.mdx
+          grep -Fq "load_config_from_file" fern/static/python-reference/scheduler-python/scheduler/configuration.mdx
+          grep -Fq "class scheduler.contracts.ScheduleAudit" fern/static/python-reference/scheduler-python/scheduler/contracts.mdx
+          grep -Fq "class scheduler.contracts.ConstraintDiagnostic" fern/static/python-reference/scheduler-python/scheduler/contracts.mdx
 
       - name: Fern check
         env:

--- a/AGENT.md
+++ b/AGENT.md
@@ -34,7 +34,7 @@ CLI help: `uv run python -m scheduler.main --help`, `uv run python -m scheduler.
 ## Layout (short)
 
 ```
-src/scheduler/     # Package: config, scheduler (Z3), server, models, writers, CLI
+src/scheduler/     # Package: problem/solver/diagnostics/audit engines, façade, config, REST, models, writers, CLI
 tests/             # pytest; @pytest.mark.slow for heavy cases
 scripts/           # export_openapi and export_config_schema
 fern/              # docs site; openapi.json and some assets are generated — do not hand-edit
@@ -47,6 +47,11 @@ skills/            # task playbooks (SKILL.md per subfolder) for assistants and 
 1. **`Course` naming**: `scheduler.config` uses `Course` as a **course-id string** type in JSON config. `scheduler.models` defines a **`Course` class** (credits, meetings, etc.). `CourseInstance.course` is the model; use **`.course.course_id`** for the config-style id. (See README “Note on naming”.)
 2. **Generated artifacts**: After changing **`src/scheduler/server.py`** or API-facing models, refresh **`fern/openapi.json`**. After **`CombinedConfig`** / config models change, refresh **`fern/docs/assets/combined-config.schema.json`**. Fern generates the Python library reference from public source and docstrings into the ignored **`fern/static/python-reference/`** directory; do not commit it. See CONTRIBUTING.
 3. **Style**: **Ruff** is authoritative (`pyproject.toml`: line length **120**, `py312`). CONTRIBUTING matches this; when in doubt follow **`pyproject.toml`**.
+4. **Architecture**: `scheduler.py` is orchestration only. Normalize shared policy in `problem.py`, own Z3 in
+   `solver.py`, put explanations/repairs in `diagnostics.py`, and mirror hard rules independently in `audit.py`.
+5. **Documentation parity**: Configuration fields, public façade methods, REST routes, API limit variables, and
+   canonical examples are checked by `tests/test_documentation_parity.py`; update the corresponding Fern guide
+   whenever one of those implementation surfaces changes.
 
 ## Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Thank you for your interest in contributing to the Course Constraint Scheduler! 
 - **Python 3.12+**: The project requires Python 3.12 or higher
 - **Git**: For version control
 - **uv**: Modern Python package manager (recommended)
+- **Node.js 22 and Docker**: Required for Fern's local Python library parser
 
 ### Installing uv
 
@@ -122,9 +123,15 @@ uv run pytest
 src/scheduler/
 ├── __init__.py             # Main package exports
 ├── config.py               # Configuration models and validation
-├── json_types.py           # TypedDict definitions for JSON structures
+├── configuration.py        # Raw loading and structured validation helpers
+├── contracts.py            # Z3-free public diagnostic/audit contracts
+├── problem.py              # Normalized solver-independent scheduling problem
+├── solver.py               # Z3 constraints, objectives, decoding, enumeration
+├── diagnostics.py          # Feasibility, unsat cores, provenance, repairs
+├── audit.py                # Independent schedule validation and scoring
+├── json_types.py           # Supplemental TypedDicts for serialized schedule rows
 ├── main.py                 # Command-line interface
-├── scheduler.py            # Core scheduling logic and Z3 integration
+├── scheduler.py            # Stable public orchestration façade
 ├── server.py               # FastAPI REST server
 ├── logging.py              # Logging configuration
 ├── models/                 # Data models
@@ -254,15 +261,19 @@ from .config import SchedulerConfig
 def generate_schedule(config: SchedulerConfig) -> List[CourseInstance]:
     """Generate a course schedule based on configuration.
 
-    **Args:**
-    - config: The scheduler configuration containing courses, faculty, and constraints.
+    Args:
+        config: The scheduler configuration containing courses, faculty, and constraints.
 
-    **Returns:**
-    A list of course instances representing the generated schedule.
+    Returns:
+        A list of course instances representing the generated schedule.
 
-    **Raises:**
-    - ValueError: If the configuration is invalid.
-    - RuntimeError: If no valid schedule can be generated.
+    Raises:
+        ValueError: If the configuration is invalid.
+        RuntimeError: If no valid schedule can be generated.
+
+    Behavior:
+        Normalize the input, solve hard constraints, optimize enabled objectives,
+        and decode one complete schedule without mutating the configuration.
 
     **Example:**
         >>> from scheduler.config import CombinedConfig
@@ -306,8 +317,9 @@ if not faculty_available:
 
 - All public functions and classes must have docstrings
 - Use Google-style docstrings for consistency
-- Include examples for complex functions
-- Document exceptions and error conditions
+- Include a high-level description plus `Args`, `Returns`, `Raises`, and `Behavior` for public callables
+- Describe every public datatype field
+- Keep exception, status, timeout, and execution-semantics documentation aligned with implementation
 
 ### API Documentation
 
@@ -321,6 +333,7 @@ if not faculty_available:
 ### User Documentation
 
 - Update **Fern** pages under **`fern/docs/pages/`** (configuration, welcome, development)
+- Update scheduling-rule and diagnostics concept pages when solver, diagnosis, audit, or objective behavior changes
 - Update README.md for new features
 - Regenerate **`fern/docs/assets/combined-config.schema.json`** with `uv run python scripts/export_config_schema.py` when `CombinedConfig` changes
 - Keep tracked Fern artifacts committed when they are used by docs publishing (`fern/openapi.json` and

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ A powerful constraint satisfaction solver for generating academic course schedul
 
 The Course Constraint Scheduler is designed to solve complex academic scheduling problems by modeling them as constraint satisfaction problems. It can handle:
 
-- **Faculty Constraints**: Availability, credit limits, course preferences
-- **Room Constraints**: Room assignments, lab requirements, capacity limits
-- **Time Constraints**: Time slot conflicts, meeting patterns, duration requirements
-- **Course Constraints**: Prerequisites, conflicts, section limits
-- **Optimization**: Multiple optimization strategies for better schedules
+- **Faculty constraints**: Availability, credit ranges, teaching-day rules, distinct-course limits, and preferences
+- **Resource constraints**: Eligible room/lab assignment and collision prevention
+- **Time constraints**: Credit/lab-compatible meeting patterns, fixed starts, alignment, overlap, and adjacency
+- **Course constraints**: Repeated sections, declared conflicts, faculty eligibility, and no-lab schedules
+- **Diagnostics and optimization**: Unsat cores, verified repairs, independent audits, and Pareto objectives
 
 ## Features
 
@@ -31,9 +31,9 @@ The Course Constraint Scheduler is designed to solve complex academic scheduling
 - **Multiple Output Formats**: JSON and CSV output support with type-safe serialization
 - **REST API**: Full HTTP API for integration with web applications
 - **Asynchronous Processing**: Background schedule generation for large problems
-- **Session Management**: Persistent sessions for iterative schedule generation
+- **Session Management**: In-memory, expiring sessions for iterative schedule generation
 - **Optimization Flags**: Configurable optimization strategies
-- **Type Safety**: Comprehensive TypedDict definitions for all JSON structures
+- **Type Safety**: Strict Pydantic configuration and response models plus typed runtime objects
 - **Enhanced Validation**: Cross-reference validation and business logic constraints
 - **Improved Error Handling**: Detailed error messages for configuration debugging
 - **Strict Type Validation**: Pydantic models with strict validation and custom type definitions
@@ -79,9 +79,20 @@ for schedule in scheduler.get_models():
     print("Schedule:")
     for course in schedule:
         print(f"{course.as_csv()}")
+
+# Diagnose hard-constraint feasibility without consuming a model
+diagnosis = scheduler.diagnose()
+
+# Independently validate and score a decoded schedule
+first_schedule = next(scheduler.get_models())
+audit = scheduler.audit_schedule(first_schedule)
 ```
 
 **Note on naming:** `scheduler.config` defines `Course` as a **course-id string** type alias (used in JSON config). `scheduler.models` defines a `Course` **class** representing a course with credits and meetings. Schedules from `get_models()` yield `CourseInstance` objects whose `.course` attribute is the models `Course`; use `.course.course_id` to get the config-style course id.
+
+`Scheduler(config, solver_timeout_ms=...)` applies an optional timeout to each Z3 check. Structured raw validation
+is available through `validate_combined_config_data`. The published **Diagnostics and auditing** guide documents
+status, core, repair, provenance, completeness, and audit-score semantics.
 
 ### REST API
 
@@ -182,78 +193,21 @@ The scheduler uses a JSON configuration file that defines:
 - **Time Slots**: Available time blocks and class patterns
 - **Optimization**: Flags for different optimization strategies
 
-Example configuration:
-
-```json
-{
-  "config": {
-    "rooms": ["Room A", "Room B"],
-    "labs": ["Lab 1"],
-    "courses": [
-      {
-        "course_id": "CS101",
-        "credits": 3,
-        "room": ["Room A"],
-        "lab": ["Lab 1"],
-        "conflicts": [],
-        "faculty": ["Dr. Smith"]
-      }
-    ],
-    "faculty": [
-      {
-        "name": "Dr. Smith",
-        "maximum_credits": 12,
-        "minimum_credits": 6,
-        "unique_course_limit": 3,
-        "times": {
-          "MON": ["09:00-17:00"],
-          "TUE": ["09:00-17:00"],
-          "WED": ["09:00-17:00"],
-          "THU": ["09:00-17:00"],
-          "FRI": ["09:00-17:00"]
-        }
-      }
-    ]
-  },
-  "time_slot_config": {
-    "times": {
-      "MON": [
-        {
-          "start": "09:00",
-          "spacing": 60,
-          "end": "17:00"
-        }
-      ]
-    },
-    "classes": [
-      {
-        "credits": 3,
-        "meetings": [
-          {
-            "day": "MON",
-            "duration": 150,
-            "lab": false
-          }
-        ]
-      }
-    ]
-  },
-  "limit": 10,
-  "optimizer_flags": ["faculty_course", "pack_rooms"]
-}
-```
+Use the validated [`tests/fixtures/minimal_config.json`](tests/fixtures/minimal_config.json) as the canonical small
+example and [`example.json`](example.json) for a larger scheduling problem. The Fern configuration guide documents
+every required field, default, validation rule, lab semantic, and time-slot generation rule.
 
 ## Architecture
 
 The scheduler is built with a modular architecture:
 
-- **Core Solver**: Z3-based constraint satisfaction engine
-- **Configuration Management**: Pydantic-based configuration validation with comprehensive error handling
-- **Model Classes**: Enhanced data structures for courses, faculty, and time slots with improved serialization
-- **JSON Types**: Comprehensive TypedDict definitions for type-safe JSON handling
-- **Output Writers**: JSON and CSV output formatters with context manager support
-- **REST Server**: FastAPI-based HTTP API with asynchronous processing and session management
-- **Session Management**: Persistent session handling for large problems with background task support
+- **SchedulingProblem**: Z3-free normalized policies, resources, time domains, source paths, and compatibility cache
+- **SolverEngine**: Z3 symbols, relation tables, hard constraints, objectives, decoding, and model blocking
+- **DiagnosticEngine**: Preflight analysis, provenance, unsat cores, suggestions, and verified repairs
+- **ScheduleAuditor**: Independent hard-rule verification, summaries, and objective scoring
+- **Scheduler**: Stable façade delegating enumeration, diagnosis, and auditing
+- **Configuration and output**: Strict Pydantic validation plus JSON/CSV writers
+- **REST server**: FastAPI sessions, serialized generation, background work, limits, and idle expiry
 
 ## Performance
 
@@ -307,7 +261,7 @@ src/scheduler/
 ├── configuration.py         # Raw and combined configuration helpers
 ├── contracts.py             # Z3-free public diagnostic result contracts
 ├── diagnostics.py           # Feasibility analysis, unsat cores, and repair sets
-├── json_types.py            # TypedDict definitions for JSON structures
+├── json_types.py            # Supplemental TypedDicts for serialized schedule rows
 ├── logging.py               # Logging setup
 ├── main.py                  # Command-line interface
 ├── problem.py               # Normalized, solver-independent scheduling problem
@@ -348,34 +302,17 @@ For questions, issues, or feature requests:
 - Create a new issue with detailed information
 - Include configuration examples and error messages
 
-## Recent Updates
+## Current diagnostic capabilities
 
-### Enhanced Configuration Validation
-- Comprehensive cross-reference validation ensures all IDs exist
-- Business logic validation prevents impossible constraints
-- Detailed error messages for easier debugging
-- Support for preference scores (0-10) with improved validation
-
-### Improved Type Safety
-- New `json_types.py` module with comprehensive TypedDict definitions
-- Type-safe JSON handling throughout the application
-- Enhanced serialization with computed fields
-- Better integration with modern Python type checking
-
-### Enhanced REST API
-- Improved session management with background task support
-- Better error handling and status codes
-- Enhanced command-line options for server configuration
-- Comprehensive API documentation with examples
-
-### Model Improvements
-- Enhanced Course and TimeSlot models with better methods
-- Improved serialization with computed fields
-- Better time handling with IntEnum for days
-- Context manager support for writers
+- Structured validation codes and JSON Pointer locations
+- Per-course candidate domains and rejected-pattern explanations
+- Faculty/resource capacity and mandatory-day feasibility analysis
+- Subset-minimal primary and bounded alternative unsat cores
+- Ranked relaxation suggestions and solver-verified repair sets
+- Provenance edges, configuration fingerprints, completeness flags, and timeout reasons
+- Independent schedule, workload, resource, preference, and objective audits
 
 ## Roadmap
 
 - [ ] Web-based configuration interface
 - [ ] Schedule visualization tools
-- [ ] Multi-objective optimization support

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -68,6 +68,12 @@ navigation:
         path: docs/pages/configuration/limit.mdx
       - page: Troubleshooting
         path: docs/pages/configuration/troubleshooting.mdx
+  - section: Concepts
+    contents:
+      - page: Scheduling rules and objectives
+        path: docs/pages/concepts/scheduling-rules.mdx
+      - page: Diagnostics and auditing
+        path: docs/pages/concepts/diagnostics-auditing.mdx
   - section: Python API
     contents:
       - page: Using the library

--- a/fern/docs/assets/combined-config.schema.json
+++ b/fern/docs/assets/combined-config.schema.json
@@ -42,7 +42,7 @@
             }
           ],
           "default": null,
-          "description": "Specific start time constraint"
+          "description": "Fixed start fallback for meetings without their own start time"
         }
       },
       "required": [
@@ -59,11 +59,11 @@
     },
     "CourseConfig": {
       "additionalProperties": false,
-      "description": "Represents a course configuration.\n\n**Usage:**\n```python\nCourseConfig(course_id=\"CS 101\", credits=3, room=[...], lab=[...], conflicts=[], faculty=[])\n```",
+      "description": "Represents a course configuration.\n\n**Usage:**\n```python\nCourseConfig(\n    course_id=\"CS 101\",\n    credits=3,\n    room=[\"Room 101\"],\n    lab=[],\n    conflicts=[],\n    faculty=[\"Dr. Smith\"],\n)\n```",
       "properties": {
         "course_id": {
           "$ref": "#/$defs/Course",
-          "description": "Unique identifier for the course"
+          "description": "Base course identifier; repeated values create separately numbered sections"
         },
         "credits": {
           "description": "Number of credit hours",
@@ -85,7 +85,7 @@
           "type": "array"
         },
         "lab": {
-          "description": "List of acceptable lab names",
+          "description": "Acceptable labs; an empty list means the course has no lab meeting",
           "example": [
             "Lab 101"
           ],
@@ -96,7 +96,7 @@
           "type": "array"
         },
         "conflicts": {
-          "description": "List of course IDs that cannot be scheduled simultaneously",
+          "description": "Base course IDs whose sections cannot overlap; an empty list means no declared conflicts",
           "items": {
             "$ref": "#/$defs/Course"
           },
@@ -115,7 +115,7 @@
               "type": "null"
             }
           ],
-          "description": "Faculty candidates, or null to derive candidates from faculty course preferences",
+          "description": "Non-empty faculty candidates, or null to derive candidates from faculty course-preference keys",
           "example": [
             "Dr. Smith"
           ],
@@ -194,7 +194,7 @@
             },
             "type": "array"
           },
-          "description": "Dictionary mapping day names to time ranges",
+          "description": "Availability ranges keyed by weekday; omitted days and empty lists mean unavailable",
           "example": {
             "MON": [
               "10:00-12:00"
@@ -297,7 +297,7 @@
             }
           ],
           "default": null,
-          "description": "Specific start time constraint"
+          "description": "Fixed start for this meeting; overrides the containing pattern start time"
         },
         "duration": {
           "description": "Duration of the meeting in minutes",
@@ -308,7 +308,7 @@
         },
         "lab": {
           "default": false,
-          "description": "Whether the meeting is in a lab",
+          "description": "Whether this is the pattern's single lab meeting",
           "title": "Lab",
           "type": "boolean"
         }
@@ -506,7 +506,7 @@
             },
             "type": "array"
           },
-          "description": "Dictionary mapping day names to time blocks",
+          "description": "Time blocks keyed by weekday; every Monday-Friday list must be non-empty",
           "propertyNames": {
             "$ref": "#/$defs/Day"
           },
@@ -514,7 +514,7 @@
           "type": "object"
         },
         "classes": {
-          "description": "List of class patterns",
+          "description": "Meeting patterns; at least one pattern must be enabled",
           "items": {
             "$ref": "#/$defs/ClassPattern"
           },
@@ -523,7 +523,7 @@
         },
         "max_time_gap": {
           "default": 30,
-          "description": "Maximum time gap between time slots to determine if they are adjacent",
+          "description": "Maximum gap in minutes used to determine whether meetings are adjacent",
           "example": 30,
           "exclusiveMinimum": 0,
           "minimum": 0,
@@ -532,7 +532,7 @@
         },
         "min_time_overlap": {
           "default": 45,
-          "description": "Minimum overlap between time slots",
+          "description": "Minimum clock-time overlap in minutes between meetings on different pattern days",
           "example": 45,
           "exclusiveMinimum": 0,
           "title": "Min Time Overlap",

--- a/fern/docs/pages/concepts/diagnostics-auditing.mdx
+++ b/fern/docs/pages/concepts/diagnostics-auditing.mdx
@@ -1,0 +1,122 @@
+---
+title: Diagnostics and auditing
+description: Validate input, explain feasibility, verify repairs, and independently audit generated schedules.
+---
+
+The scheduler exposes three complementary checks:
+
+| Check | When to use it | Invokes Z3 | Changes enumeration |
+|---|---|---:|---:|
+| Configuration validation | Before constructing a scheduler or REST session. | No | No |
+| Feasibility diagnosis | When you need to understand whether all hard rules can be satisfied. | Yes | No |
+| Schedule audit | After generation, or for a caller-supplied decoded schedule. | No | No |
+
+## Validate raw configuration
+
+Python callers can validate an untrusted mapping without catching Pydantic exceptions:
+
+```python
+from scheduler import validate_combined_config_data
+
+result = validate_combined_config_data(payload)
+if not result.is_valid:
+    for finding in result.diagnostics:
+        print(finding.code, finding.path, finding.message)
+else:
+    print(result.configuration_fingerprint)
+```
+
+REST callers use `POST /validate`. Configuration failures are returned as a successful structured response with
+`is_valid: false`; the endpoint does not create a session or invoke Z3. Each finding has a stable code and JSON
+Pointer path. Valid input receives a SHA-256 fingerprint of its canonical JSON representation.
+
+## Diagnose feasibility
+
+```python
+diagnosis = scheduler.diagnose()
+print(diagnosis.status, diagnosis.diagnostic_completeness)
+```
+
+REST callers use `GET /schedules/{schedule_id}/diagnosis`. Diagnosis uses only hard constraints and does not run
+soft objectives, consume a generated model, or alter later `get_models()` results.
+
+`status` is one of:
+
+- `satisfiable` — all tracked hard rules can be satisfied.
+- `unsatisfiable` — the hard rules conflict.
+- `unknown` — Z3 could not decide within the configured check conditions, commonly because of a timeout.
+
+The response can include:
+
+- `candidate_domains`: eligible faculty, rooms, labs, compatible patterns, availability counts, and bounded rejected
+  pattern explanations for every course.
+- `capacity_analysis`: necessary-condition workload, mandatory-day, pairwise separation, forced-resource, and
+  singleton-pattern checks.
+- `day_feasibility`: every faculty/day cell with availability, eligible courses, and compatible/available patterns.
+- `preflight_findings`: deterministic contradictions and relevant derived facts found before core extraction.
+- `conflicting_constraints`: one subset-minimal unsatisfiable business-rule core.
+- `alternative_conflict_sets`: other bounded subset-minimal cores.
+- `supporting_facts`: configuration and workload facts needed to interpret the primary core.
+- `relaxation_suggestions`: ranked edits inferred from findings; these are suggestions, not solver proofs.
+- `repair_sets`: bounded rule combinations that the solver verified restore feasibility when relaxed.
+- `provenance`: directed links from configuration paths to candidate domains and core findings.
+
+`core_is_minimal`, `alternative_cores_complete`, and `repair_sets_complete` distinguish proven properties from
+bounded searches. `diagnostic_completeness` is `hard_constraint_feasibility`, `bounded_unsat_cores`, or
+`preflight_only`; `diagnostic_version` identifies the payload semantics. An `unknown` result also supplies `reason`,
+`elapsed_ms`, and the active `solver_timeout_ms`.
+
+Built-in diagnostic work bounds are part of those completeness semantics:
+
+- Rejected-pattern detail is limited to 128 records per course while `rejected_pattern_count` retains the total.
+- Static pair feasibility checks compare at most 4,096 pattern pairs; an indeterminate capped comparison is omitted
+  rather than reported as feasible or infeasible.
+- Alternative-core search returns at most 16 alternatives and performs at most 128 solver checks.
+- Repair search returns at most 5 verified sets and performs at most 64 solver checks.
+
+The solver timeout applies independently to each Z3 check, not to the complete multi-check diagnosis. Therefore
+`elapsed_ms` can exceed `solver_timeout_ms` during bounded core and repair searches.
+
+## Fingerprints and locations
+
+Diagnostic locations are JSON Pointers into the submitted `CombinedConfig`. The diagnosis fingerprint and a valid
+configuration-validation fingerprint match when both are calculated from the same canonical configuration. This
+lets clients associate cached explanations with the exact input that produced them.
+
+## Audit a generated schedule
+
+```python
+schedule = next(scheduler.get_models())
+audit = scheduler.audit_schedule(schedule)
+assert audit.is_valid
+```
+
+REST callers use `GET /schedules/{schedule_id}/audit/{index}` for a previously generated index. The independent,
+Z3-free auditor reconstructs all hard rules from normalized policies rather than trusting the model that produced
+the schedule. It reports:
+
+- `constraint_violations`: hard-rule failures, including missing/duplicate course coverage.
+- `faculty_workloads`: credits, distinct courses, teaching days, configured limits, and mandatory-day satisfaction
+  for every faculty member.
+- `resource_usage`: room and lab assignments plus independently detected collisions.
+- `objective_scores`: achieved scores for every enabled optimizer flag.
+- `preference_outcomes`: objective points that were available but not selected.
+
+An objective's `independent_upper_bound` ignores hard constraints and competition between objectives. It is useful
+context, but it is not a claim that the bound is jointly attainable.
+
+Python auditing accepts any decoded `list[CourseInstance]`; the REST audit endpoint only audits models retained by
+that session. Neither form advances enumeration.
+
+## Contract reference map
+
+All contracts are immutable dataclasses and are exported from both `scheduler` and the legacy
+`scheduler.scheduler` path:
+
+- Validation: `ConfigurationDiagnostic`, `ConfigurationValidationResult`.
+- Feasibility: `ScheduleDiagnosis`, `ConstraintDiagnostic`, `CandidateDomainDiagnostic`, `CapacityDiagnostic`,
+  `DayFeasibilityDiagnostic`, `ProvenanceEdge`, `RelaxationSuggestion`, `RepairSetDiagnostic`.
+- Auditing: `ScheduleAudit`, `FacultyWorkloadDiagnostic`, `ResourceUsageDiagnostic`, `ObjectiveScoreDiagnostic`.
+
+The generated Python **Reference** describes every field in declaration order. `load_config_from_file`,
+`validate_combined_config_data`, and `get_faculty_availability` retain their legacy import compatibility as well.

--- a/fern/docs/pages/concepts/scheduling-rules.mdx
+++ b/fern/docs/pages/concepts/scheduling-rules.mdx
@@ -1,0 +1,72 @@
+---
+title: Scheduling rules and objectives
+description: The complete hard-constraint and soft-objective behavior enforced by the scheduler.
+---
+
+The scheduler first enforces every hard rule below. When `optimizer_flags` are enabled, it then searches the
+feasible schedules for Pareto-optimal objective values. An optimizer flag can rank feasible schedules, but it can
+never relax a hard rule.
+
+## Course assignments
+
+Every configured course section receives exactly one faculty member, room, and compatible meeting pattern.
+
+- Faculty and rooms must come from the course's eligible lists.
+- `faculty: null` derives eligibility from faculty members who have a `course_preferences` key for the course.
+- A course with a non-empty `lab` list receives exactly one listed lab for its single lab-marked meeting.
+- A course with `lab: []` uses a no-lab pattern and its generated `lab` and `lab_index` values are `null`.
+- The meeting pattern must have matching credits and matching lab presence.
+- The assigned pattern must fit entirely within the assigned faculty member's availability.
+
+Repeated `course_id` values are separate sections, numbered in configuration order (`CS101.01`, `CS101.02`, and
+so on). A `conflicts` entry names the base course id and therefore applies to every matching section.
+
+## Faculty workload
+
+The following rules are evaluated for every configured faculty member, even when that person is not eligible for
+any course:
+
+- Assigned credits must remain between `minimum_credits` and `maximum_credits`, inclusive.
+- The number of distinct base course ids must not exceed `unique_course_limit`.
+- The number of teaching weekdays must not exceed `maximum_days`.
+- Every `mandatory_days` value must contain at least one assigned meeting.
+- Every assigned meeting must fit within a configured availability range.
+
+Consequently, a faculty member with no eligible courses cannot satisfy a positive minimum-credit requirement or a
+mandatory teaching day.
+
+## Conflicts and shared resources
+
+- Courses that declare a conflict cannot overlap.
+- Different sections of the same base course cannot overlap.
+- Two assignments using the same room cannot have any overlapping meetings, including lab-marked meetings.
+- Two assignments using the same lab cannot have overlapping lab meetings.
+- Courses taught by the same faculty member cannot overlap.
+
+Additional same-faculty rules use `max_time_gap` to decide whether two meetings are adjacent:
+
+- Sections of the same course taught by one faculty member use the same room or lab when their corresponding
+  candidate lists intersect, and have adjacent meeting and lab pairs.
+- Different courses taught by one faculty member must not have adjacent meeting pairs; when both use labs,
+  their lab meetings must not be adjacent.
+
+## Optimizer objectives
+
+Enabled objectives are registered in a fixed order and optimized with Z3's Pareto priority. The order of strings
+inside `optimizer_flags` does not change that registration order.
+
+| Flag | Score added |
+|---|---|
+| `faculty_course` | The assigned faculty member's configured score for the course id. |
+| `faculty_room` | The assigned faculty member's configured score for the selected room. |
+| `faculty_lab` | The assigned faculty member's configured score for the selected lab. No-lab courses add zero. |
+| `same_room` | One point for each eligible course pair taught by the same faculty member in the same room. |
+| `same_lab` | One point for each eligible lab-course pair taught by the same faculty member in the same lab. |
+| `pack_rooms` | One point for different-course pairs using the same room when any meeting pair is adjacent. |
+| `pack_labs` | One point for different-course pairs using the same lab at adjacent lab times. |
+
+Missing preference keys and explicit preference value `0` contribute zero. Each generated schedule is blocked
+before the next solver check, so enumeration yields distinct complete assignments until `limit`, solver exhaustion,
+or an indeterminate solver result is reached.
+
+Use **Diagnostics and auditing** to inspect why a configuration is infeasible or how a generated schedule scores.

--- a/fern/docs/pages/configuration/courses.mdx
+++ b/fern/docs/pages/configuration/courses.mdx
@@ -3,7 +3,8 @@ title: Courses
 description: Course entries under config.courses — credits, rooms, labs, conflicts, and faculty.
 ---
 
-Each object in **`config.courses`** describes one course section family the solver may schedule.
+The required **`courses`** list at `config.courses` contains each course section the solver must schedule. The list
+itself may be empty, although a normal scheduling problem contains at least one course.
 
 ## Example
 
@@ -22,11 +23,11 @@ Each object in **`config.courses`** describes one course section family the solv
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `course_id` | Yes | Unique string id for the course. |
+| `course_id` | Yes | Base string id. Repeated values create separately numbered sections. |
 | `credits` | Yes | Positive integer; must match an allowed pattern in `time_slot_config.classes`. |
 | `room` | Yes | Non-empty list of allowed **room** names (subset of `config.rooms`). |
-| `lab` | No | List of allowed **lab** names (subset of `config.labs`); may be empty. |
-| `conflicts` | No | Other `course_id` values that must not overlap in time with this course. |
+| `lab` | No | Allowed lab names; defaults to `[]`, which means the course has no lab meeting. |
+| `conflicts` | Yes | Other base `course_id` values that must not overlap; use `[]` for none. |
 | `faculty` | Yes | Non-empty list of faculty names, or `null` to derive candidates from matching faculty `course_preferences`. |
 
 ## Validation rules
@@ -36,9 +37,12 @@ Each object in **`config.courses`** describes one course section family the solv
 - Every course credit value needs at least one enabled class pattern. A course with labs needs a pattern with one lab meeting; a course without labs needs a pattern with none.
 - Every `conflicts` entry must be a valid `course_id` of another course (not yourself).
 - A course cannot list itself in `conflicts`.
+- A conflict names the base id, so it applies to every section with that id. Conflict declarations need not be
+  symmetric: either course listing the other is sufficient for solver separation.
 
 ## Practices
 
 - Use consistent `course_id` naming (e.g. subject + number).
+- Repeat a complete course entry when multiple sections must be scheduled; sections are numbered in input order.
 - Multiple rooms/labs give the solver flexibility and often improve feasibility.
 - Model real registration conflicts explicitly in `conflicts`.

--- a/fern/docs/pages/configuration/faculty.mdx
+++ b/fern/docs/pages/configuration/faculty.mdx
@@ -3,7 +3,8 @@ title: Faculty
 description: Faculty workload, availability, day caps, and preference maps under config.faculty.
 ---
 
-Each object in **`config.faculty`** describes one instructor and their rules.
+The required **`faculty`** list at `config.faculty` contains instructor policies. The list may be empty only for a
+configuration with no courses requiring an explicit or derived faculty candidate.
 
 ## Example
 
@@ -33,12 +34,12 @@ Each object in **`config.faculty`** describes one instructor and their rules.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Unique display id; referenced from courses. |
-| `maximum_credits` | Yes | Upper bound on total credits taught. |
-| `minimum_credits` | Yes | Lower bound on total credits taught. |
-| `unique_course_limit` | Yes | Max number of distinct courses they may teach. |
-| `maximum_days` | No | Max distinct weekdays they teach (default 5). |
+| `maximum_credits` | Yes | Inclusive upper bound on total credits; integer `0` or greater. |
+| `minimum_credits` | Yes | Inclusive lower bound on total credits; integer `0` or greater. |
+| `unique_course_limit` | Yes | Positive maximum number of distinct base course ids they may teach. |
+| `maximum_days` | No | Integer `0`–`5`; maximum distinct teaching weekdays (default `5`). |
 | `mandatory_days` | No | Weekdays on which they must teach at least once (default none). |
-| `times` | Yes | Map day → list of `HH:MM-HH:MM` availability ranges (non-empty per listed day). |
+| `times` | Yes | Map day → list of `HH:MM-HH:MM` availability ranges; omitted days and empty lists mean unavailable. |
 | `course_preferences` | No | Map `course_id` → score `0`–`10`. |
 | `room_preferences` | No | Map room name → score `0`–`10`. |
 | `lab_preferences` | No | Map lab name → score `0`–`10`. |
@@ -50,6 +51,7 @@ Each object in **`config.faculty`** describes one instructor and their rules.
 - `maximum_days` ≥ number of `mandatory_days`.
 - Preference keys must reference existing courses / rooms / labs.
 - Faculty `name` values must be unique.
+- Availability ranges require `end` later than `start`; ranges are not merged or inferred.
 
 ## Time format
 
@@ -58,7 +60,10 @@ Each object in **`config.faculty`** describes one instructor and their rules.
 
 ## Preference scale
 
-- **0** — no preference (default if omitted).
+- **0** — no objective contribution. An omitted key also contributes zero.
 - **1–3** — low, **4–6** — medium, **7–8** — high, **9–10** — very high.
 
 Preferences interact with **optimizer flags** (see **Optimizer flags**).
+
+For a course with `faculty: null`, the presence of the course id as a `course_preferences` key makes this faculty
+eligible even when its score is `0`. Explicit course faculty lists are never expanded from preferences.

--- a/fern/docs/pages/configuration/limit.mdx
+++ b/fern/docs/pages/configuration/limit.mdx
@@ -16,6 +16,9 @@ description: Top-level limit — maximum schedules to generate in the Python API
 - **CLI** — `--limit` can override; align it with your JSON if you use both.
 - **REST API** — Session stores up to `limit` schedules via `.../next` and `generate_all`; `.../count` compares progress to `limit`.
 
+The REST server additionally rejects values above `SCHEDULER_API_MAX_SCHEDULES` (default `100`). That safeguard is
+server-only; direct Python and CLI use the positive `limit` from configuration or the CLI override.
+
 ## Practices
 
 - Lower **`limit`** for faster turnaround while prototyping.

--- a/fern/docs/pages/configuration/optimizer-flags.mdx
+++ b/fern/docs/pages/configuration/optimizer-flags.mdx
@@ -25,13 +25,15 @@ description: Optional optimizer_flags that steer soft objectives on top of hard 
 | `faculty_course` | Prefer faculty–course assignment by course preferences. |
 | `faculty_room` | Prefer faculty–room preferences. |
 | `faculty_lab` | Prefer faculty–lab preferences. |
-| `same_room` | Prefer keeping a course in one room when possible. |
-| `same_lab` | Prefer keeping a course in one lab when possible. |
-| `pack_rooms` | Prefer fewer distinct rooms overall. |
-| `pack_labs` | Prefer fewer distinct labs overall. |
+| `same_room` | Prefer eligible course pairs taught by one faculty member to share a room. |
+| `same_lab` | Prefer eligible lab-course pairs taught by one faculty member to share a lab. |
+| `pack_rooms` | Prefer different courses to use the same room when any meeting pair is adjacent. |
+| `pack_labs` | Prefer different courses to use the same lab at adjacent lab times. |
 
 ## Practices
 
 - Start with `faculty_course` and add resource flags as needed.
 - More flags can **increase** solve time; tune for your instance size.
 - Hard constraints (availability, conflicts, etc.) are always enforced; flags affect **preferences**, not feasibility.
+- Objectives use Pareto priority and a fixed registration order; rearranging the flag strings does not change it.
+- Objective audit upper bounds score each item independently and may not be jointly attainable.

--- a/fern/docs/pages/configuration/overview.mdx
+++ b/fern/docs/pages/configuration/overview.mdx
@@ -17,6 +17,8 @@ The Course Constraint Scheduler uses a **JSON** configuration that defines the s
 - **Cross-references** — Course rooms/labs/faculty/conflicts must name entities that exist in `config`.
 - **Business rules** — e.g. faculty min/max credits, mandatory days, no self-conflicts.
 - **Strict types** — Times and ranges use fixed string patterns (see below).
+- **No unknown keys** — Every model uses `extra="forbid"`; misspelled or future fields fail validation.
+- **No coercion** — `strict=True` rejects values such as a numeric string where an integer is required.
 
 ## Type aliases (conceptual)
 
@@ -28,7 +30,7 @@ These are enforced in JSON via patterns and constraints:
 | `TimeRangeString` | `HH:MM-HH:MM` |
 | `Preference` | Integer `0`–`10` |
 | `Day` | `MON`, `TUE`, `WED`, `THU`, or `FRI` |
-| Room / lab / course / faculty ids | Strings; rooms/labs/faculty names must be unique where required |
+| Room / lab / course / faculty ids | Strings; room, lab, and faculty names are unique; repeated course ids create sections |
 
 ## JSON Schema
 
@@ -47,74 +49,15 @@ uv run python scripts/export_config_schema.py
 
 The **REST API** `POST /submit` body matches this shape (same model as `CombinedConfig`).
 
-## Full example
+## Valid complete examples
 
-```json
-{
-  "config": {
-    "rooms": ["Room A", "Room B", "Room C"],
-    "labs": ["Lab 1", "Lab 2"],
-    "courses": [
-      {
-        "course_id": "CS101",
-        "credits": 3,
-        "room": ["Room A", "Room B"],
-        "lab": ["Lab 1"],
-        "conflicts": ["CS102"],
-        "faculty": ["Dr. Smith", "Dr. Johnson"]
-      },
-      {
-        "course_id": "CS102",
-        "credits": 4,
-        "room": ["Room B", "Room C"],
-        "lab": ["Lab 2"],
-        "conflicts": ["CS101"],
-        "faculty": ["Dr. Johnson", "Dr. Brown"]
-      }
-    ],
-    "faculty": [
-      {
-        "name": "Dr. Smith",
-        "maximum_credits": 12,
-        "minimum_credits": 6,
-        "unique_course_limit": 3,
-        "maximum_days": 4,
-        "mandatory_days": ["MON", "WED"],
-        "times": {
-          "MON": ["09:00-17:00"],
-          "TUE": ["09:00-17:00"],
-          "WED": ["09:00-17:00"],
-          "THU": ["09:00-17:00"],
-          "FRI": ["09:00-17:00"]
-        },
-        "course_preferences": { "CS101": 10, "CS102": 5 },
-        "room_preferences": { "Room A": 10, "Room B": 7, "Room C": 3 },
-        "lab_preferences": { "Lab 1": 8, "Lab 2": 5 }
-      }
-    ]
-  },
-  "time_slot_config": {
-    "times": {
-      "MON": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
-      "TUE": [{ "start": "09:00", "spacing": 60, "end": "17:00" }]
-    },
-    "classes": [
-      {
-        "credits": 3,
-        "meetings": [{ "day": "MON", "duration": 150, "lab": false }]
-      },
-      {
-        "credits": 4,
-        "meetings": [
-          { "day": "TUE", "duration": 150, "lab": true },
-          { "day": "THU", "duration": 150, "lab": false }
-        ]
-      }
-    ]
-  },
-  "limit": 10,
-  "optimizer_flags": ["faculty_course", "pack_rooms", "same_room"]
-}
-```
+The repository keeps complete configurations executable instead of duplicating untested JSON in several guides:
+
+- [`tests/fixtures/minimal_config.json`](https://github.com/mucsci/scheduler/blob/main/tests/fixtures/minimal_config.json)
+  is the canonical minimal configuration used by unit, integration, Python, and REST tests.
+- [`example.json`](https://github.com/mucsci/scheduler/blob/main/example.json) is a larger multi-course example,
+  including repeated sections and preference-derived faculty candidates.
+
+Both files are validated as `CombinedConfig` in the documentation parity tests.
 
 Continue with **Rooms and labs**, **Courses**, **Faculty**, and **Time slots** for field-level detail.

--- a/fern/docs/pages/configuration/rooms-labs.mdx
+++ b/fern/docs/pages/configuration/rooms-labs.mdx
@@ -17,7 +17,8 @@ Under **`config`**, **`rooms`** and **`labs`** name the physical resources the s
 - **`rooms`** — Non-empty list of unique room names (strings).
 - **`labs`** — List of unique lab names (strings); may be empty if you have no labs.
 
-Every room and lab name used in **courses** or **faculty preferences** must appear in these lists.
+Room and lab names must be unique. Every name used in **courses** or **faculty preferences** must appear in these
+lists.
 
 ## Course usage
 

--- a/fern/docs/pages/configuration/time-slots.mdx
+++ b/fern/docs/pages/configuration/time-slots.mdx
@@ -1,78 +1,82 @@
 ---
 title: Time slots
-description: time_slot_config.times grids and classes patterns that define legal meeting shapes per credit hour.
+description: Time grids, meeting patterns, fixed starts, overlap alignment, and adjacency settings.
 ---
 
-**`time_slot_config`** has two parts:
+`time_slot_config` has four fields:
 
-1. **`times`** — For each weekday, one or more blocks `{ start, spacing, end }` that define discrete start times (spacing in minutes).
-2. **`classes`** — Allowed **meeting patterns** per credit value: lists of `{ day, duration, lab }` meetings.
+| Field | Required | Default | Meaning |
+|---|---:|---:|---|
+| `times` | Yes | — | A non-empty list of time blocks for every weekday. |
+| `classes` | Yes | — | Enabled and disabled meeting patterns grouped by credit value. |
+| `max_time_gap` | No | `30` | Maximum minutes between meetings for adjacency checks. |
+| `min_time_overlap` | No | `45` | Required clock-time overlap between meetings on different days in one pattern. |
 
-The solver only assigns courses to slots that match a **class pattern** whose `credits` equals the course’s credits.
+Both numeric settings are positive integers. `max_time_gap` is used by same-faculty hard rules and the packing
+objectives described under **Scheduling rules and objectives**.
 
 ## Time blocks
 
+Each of `MON`, `TUE`, `WED`, `THU`, and `FRI` must be present with at least one block:
+
 ```json
 {
-  "times": {
-    "MON": [
-      { "start": "09:00", "spacing": 60, "end": "17:00" }
-    ],
-    "TUE": [
-      { "start": "08:00", "spacing": 60, "end": "16:00" }
-    ]
-  }
+  "MON": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
+  "TUE": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
+  "WED": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
+  "THU": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
+  "FRI": [{ "start": "09:00", "spacing": 60, "end": "17:00" }]
 }
 ```
 
 | Field | Description |
-|-------|-------------|
-| `start` | First slot start (`HH:MM`). |
-| `spacing` | Minutes between consecutive starts. |
-| `end` | End of the block; last start must still fit a full meeting. |
+|---|---|
+| `start` | First candidate start in 24-hour `HH:MM`. |
+| `spacing` | Positive minutes between consecutive candidate starts. |
+| `end` | Exclusive fitting boundary; a meeting must end at or before this value. |
 
-**Rules:** `end` must be after `start`; spacing is a positive integer.
+`end` must be later than `start`. Multiple blocks per day are allowed. Candidate starts advance from `start` by
+`spacing` until the complete meeting would no longer fit.
 
 ## Class patterns
 
 ```json
 {
-  "credits": 3,
+  "credits": 4,
   "meetings": [
-    { "day": "MON", "duration": 150, "lab": false }
+    { "day": "MON", "duration": 110, "lab": true },
+    { "day": "WED", "start_time": "10:00", "duration": 110, "lab": false }
   ],
+  "start_time": "09:00",
   "disabled": false
 }
 ```
 
-| Field | Description |
-|-------|-------------|
-| `credits` | Credit hours for this shape; must match courses using it. |
-| `meetings` | Non-empty; each meeting has `day`, `duration` (minutes), optional `lab` (default false). |
-| `disabled` | If true, pattern is ignored (default false). |
-| `start_time` | Optional fixed start `HH:MM` for tighter placement. |
+| Field | Required | Default | Description |
+|---|---:|---:|---|
+| `credits` | Yes | — | Positive credit value matched against courses. |
+| `meetings` | Yes | — | Non-empty meetings with distinct weekdays. |
+| `disabled` | No | `false` | Excludes the complete pattern when true. |
+| `start_time` | No | `null` | Pattern-level fixed `HH:MM` start fallback. |
 
-**Rules:**
+Each meeting has required `day` and positive `duration`, plus optional `lab` (default `false`) and `start_time`
+(default `null`). A meeting-level start overrides the pattern-level start for that meeting. Meetings without either
+fixed start use the day's block spacing.
 
-- No duplicate `day` in the same pattern’s `meetings`.
-- `day` ∈ `MON` … `FRI`.
-- Durations are positive integers.
+## Generated combinations
 
-## Multi-day example
+For each enabled pattern with matching credits, the generator forms the Cartesian product of each meeting's legal
+starts, then retains combinations that satisfy all of these rules:
 
-```json
-{
-  "credits": 4,
-  "meetings": [
-    { "day": "MON", "duration": 75, "lab": false },
-    { "day": "WED", "duration": 75, "lab": false },
-    { "day": "FRI", "duration": 150, "lab": true }
-  ]
-}
-```
+- Every meeting fits completely inside one block for its weekday.
+- Pattern weekdays are distinct, so same-day meeting overlap is rejected defensively rather than normally used.
+- Every pair of meetings on different days overlaps in clock time by at least `min_time_overlap` minutes.
+- A multi-meeting pattern has at least two meetings sharing the same clock start. A one-meeting pattern always
+  satisfies this rule.
+- Duplicate complete `TimeSlot` values are removed while preserving generation order.
 
-## Practices
+A pattern may mark at most one meeting with `lab: true`. Courses with non-empty lab candidates can use only
+patterns with one lab meeting; courses with `lab: []` can use only patterns with no lab meeting. Every course credit
+value must have at least one enabled pattern with matching lab presence.
 
-- Align **durations** and **spacing** with your registrar’s standard lengths (e.g. 50, 75, 150 minutes).
-- Every **credit** value that appears on a course must have at least one enabled **class** pattern.
-- Use `disabled` to retire patterns without deleting them.
+Use `disabled` to retain a historical pattern without making it available to the solver.

--- a/fern/docs/pages/configuration/troubleshooting.mdx
+++ b/fern/docs/pages/configuration/troubleshooting.mdx
@@ -5,10 +5,11 @@ description: Validation errors, performance, and incremental debugging for JSON 
 
 ## Required sections
 
-These must be present and non-empty where noted:
+These must be present. Only the collections explicitly described as non-empty have that requirement:
 
-- `config.rooms`, `config.courses`, `config.faculty`
-- `time_slot_config.times`, `time_slot_config.classes`
+- `config.rooms` (non-empty), `config.labs`, `config.courses`, `config.faculty`
+- `time_slot_config.times` (every weekday has a non-empty block list), `time_slot_config.classes` (at least one
+  enabled pattern)
 
 ## Common validation errors
 
@@ -82,7 +83,8 @@ logging.basicConfig(level=logging.DEBUG)
 
 ## Incremental authoring
 
-1. Start from a minimal config (see repository `tests/fixtures/minimal_config.json`).
+1. Start from the validated
+   [`tests/fixtures/minimal_config.json`](https://github.com/mucsci/scheduler/blob/main/tests/fixtures/minimal_config.json).
 2. Add courses one at a time and re-validate.
 3. Add faculty and time patterns before enabling optimizations.
 
@@ -93,55 +95,5 @@ logging.basicConfig(level=logging.DEBUG)
 3. Document institutional rules in `conflicts`, `mandatory_days`, and availability.
 4. Match **credits** on courses to **class patterns** exactly.
 
-### Basic template
-
-```json
-{
-  "config": {
-    "rooms": ["Room 1", "Room 2"],
-    "labs": ["Lab 1"],
-    "courses": [
-      {
-        "course_id": "COURSE101",
-        "credits": 3,
-        "room": ["Room 1", "Room 2"],
-        "lab": ["Lab 1"],
-        "conflicts": [],
-        "faculty": ["Faculty1"]
-      }
-    ],
-    "faculty": [
-      {
-        "name": "Faculty1",
-        "maximum_credits": 12,
-        "minimum_credits": 6,
-        "unique_course_limit": 3,
-        "times": {
-          "MON": ["09:00-17:00"],
-          "TUE": ["09:00-17:00"],
-          "WED": ["09:00-17:00"],
-          "THU": ["09:00-17:00"],
-          "FRI": ["09:00-17:00"]
-        }
-      }
-    ]
-  },
-  "time_slot_config": {
-    "times": {
-      "MON": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
-      "TUE": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
-      "WED": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
-      "THU": [{ "start": "09:00", "spacing": 60, "end": "17:00" }],
-      "FRI": [{ "start": "09:00", "spacing": 60, "end": "17:00" }]
-    },
-    "classes": [
-      {
-        "credits": 3,
-        "meetings": [{ "day": "MON", "duration": 150, "lab": false }]
-      }
-    ]
-  },
-  "limit": 10,
-  "optimizer_flags": ["faculty_course"]
-}
-```
+The **Configuration overview** links both the canonical minimal fixture and the larger executable `example.json`;
+use those files instead of copying an unvalidated template.

--- a/fern/docs/pages/dev/config-options.mdx
+++ b/fern/docs/pages/dev/config-options.mdx
@@ -10,12 +10,18 @@ User-visible JSON is defined by **`src/scheduler/config.py`** using Pydantic v2 
 1. **Model** — Add fields to the appropriate nested model (`SchedulerConfig`, `FacultyConfig`, `CourseConfig`, `TimeSlotConfig`, etc.) or top-level **`CombinedConfig`**.
 2. **Types** — Reuse **`TimeString`**, **`TimeRangeString`**, **`Preference`**, **`Day`**, or add new **`Annotated[..., Field(...)]`** aliases for reuse and JSON Schema quality.
 3. **Validators** — Use **`field_validator`** / **`model_validator`** for cross-field rules; keep error messages explicit.
-4. **Consumption** — Read the new fields from **`Scheduler`** (or **`TimeSlotGenerator`**, server, CLI) where behavior should change.
-5. **Docs** — Update the **Configuration** pages in this site and add/fix tests.
+4. **Normalization** — Add solver-independent policy state or cached queries to **`SchedulingProblem`** when more
+   than one engine consumes the value.
+5. **Consumption** — Implement Z3 behavior in **`SolverEngine`**, diagnostics in **`DiagnosticEngine`**, and an
+   independent verification path in **`ScheduleAuditor`** where applicable. Keep `Scheduler` as delegation only.
+6. **Docs** — Update the **Configuration** pages, executable examples, schema, and parity tests.
 
 ## Strictness
 
 Because **`extra="forbid"`**, clients get errors on unknown keys — document new keys in the changelog and configuration pages when you ship them.
+
+Combined rules that depend on multiple sub-models belong on `CombinedConfig`. Raw non-throwing validation is
+adapted by `validate_combined_config_data`; do not create a separate set of REST-only validation semantics.
 
 ## JSON Schema
 

--- a/fern/docs/pages/dev/constraints.mdx
+++ b/fern/docs/pages/dev/constraints.mdx
@@ -1,27 +1,61 @@
 ---
-title: Adding constraints
-description: Where Z3 constraints are built in scheduler.py and how they compose.
+title: Architecture and adding constraints
+description: How normalized problems, Z3 artifacts, diagnostics, auditing, and the public façade compose.
 ---
 
-Hard scheduling rules are expressed as Z3 boolean formulas in **`src/scheduler/scheduler.py`** on the **`Scheduler`** class.
+`Scheduler` is a stable orchestration façade. It constructs four components and delegates its three public methods:
 
-## Lifecycle
+1. `SchedulingProblem.from_config` normalizes validated configuration, faculty/course policies, source paths,
+   generated time domains, and cached compatibility queries without importing Z3.
+2. `SolverEngine` owns the Z3 context, deterministic enum symbols, `CourseVariables`, relation tables, hard
+   constraints, optimizer objectives, model decoding, and model blocking.
+3. `DiagnosticEngine` consumes the normalized problem and immutable `SolverArtifacts` to perform preflight
+   analysis, tracked hard-rule checks, unsat-core search, provenance, suggestions, and verified repairs.
+4. `ScheduleAuditor` independently reconstructs hard rules and objective scores without importing or querying Z3.
 
-1. **`__init__`** loads configuration, builds internal **`Course`** / time-slot structures, creates Z3 sorts and per-course variables, then assembles constraints.
-2. **`_build_function_constraints`** — Declares abstract functions over time slots (`overlaps`, `lab_overlaps`, `lecture_next_to`, `faculty_available`, `lab_next_to`) and wires them to concrete slot facts.
-3. **`_build_faculty_constraints`** — Credit totals, unique-course caps, optional max/mandatory days, availability.
-4. **`_build_course_constraints`** — Per-course room/lab choice, time choice, faculty choice, conflict exclusions, faculty availability linkage.
-5. **`_build_resource_constraints`** — No double-booking of rooms/labs/faculty; section adjacency rules for same vs different courses.
-6. **`_aggregate_constraints`** — Combines lists and attaches the optimizer (soft goals) from **`optimizer_flags`**.
+Public diagnostic result dataclasses live in `contracts.py`; raw loading and structured validation live in
+`configuration.py`. Do not move Z3 ownership back into `scheduler.py` or add parallel state to the façade.
 
-## Adding a new hard constraint
+## Add or change a hard rule
 
-1. Decide whether it is **local** (one course) or **cross-course** / **global**.
-2. Add a **`_build_*`** helper or extend an existing one, returning additional **`z3.BoolRef`** terms.
-3. Fold the result into **`_aggregate_constraints`** (or the appropriate caller) so every `check()` / `get_models()` sees it.
-4. Add **tests** under `tests/` with small configs that pass/fail as expected.
-5. If users must configure it, extend **`CombinedConfig`** / sub-models in **`config.py`** (see **Adding configuration options**).
+1. Decide which normalized policy or compatibility data the rule needs. Add it to `SchedulingProblem` only when it
+   is shared by solving, diagnosis, or auditing.
+2. Encode the authoritative Z3 rule in the appropriate `SolverEngine._build_*_constraints` family.
+3. Add a `DiagnosticConstraintArtifact` with a stable `kind`, precise subjects, and source locations so diagnosis
+   can track the business rule rather than an opaque aggregate formula.
+4. Mirror the rule independently in `ScheduleAuditor`; do not reuse a Z3 expression as the audit implementation.
+5. Add static candidate/capacity/day analysis in `DiagnosticEngine` when the rule has a useful necessary condition.
+6. Update **Scheduling rules and objectives**, relevant configuration pages, and diagnostic guidance.
 
-## Performance
+Keep tracked constraints granular enough that a subset-minimal core identifies one actionable business rule.
+Aggregating unrelated faculty, course, or resource rules under one tracker makes cores and repair sets less useful.
 
-Constraint count grows with courses × slots × faculty. Prefer batched implications (the file already batches several patterns) over naive pairwise loops when you touch large loops.
+## Add or change an objective
+
+1. Add or reuse an `OptimizerFlags` value in configuration.
+2. Register the Z3 objective in `SolverEngine.get_models` without changing established ordering for existing flags.
+3. Recalculate the same contribution in `ScheduleAuditor._objective_diagnostics`, including an independent upper
+   bound and unmet-outcome explanation.
+4. Add optimized solver tests, audit-score tests, and documentation for exact point contribution.
+
+## Compatibility requirements
+
+- Preserve `Scheduler(full_config, *, solver_timeout_ms=None)` and the behavior of `get_models()`, `diagnose()`, and
+  `audit_schedule()`.
+- Preserve root exports and legacy imports from `scheduler.scheduler`.
+- Keep generated ordering, timeout handling, no-lab decoding, deterministic symbols, and model blocking covered by
+  characterization tests.
+- `Course.time`, `faculty`, `room`, and `lab` remain compatibility mirrors; new internal logic uses
+  `CourseVariables` from solver artifacts.
+
+## Testing layers
+
+- Problem normalization and compatible-domain caching: `test_problem.py`.
+- Constraint families, objectives, decoding, and timeouts: `test_solver_engine.py`.
+- Preflight, cores, repairs, and completeness: `test_diagnostic_engine.py`.
+- Independent rules and scoring: `test_schedule_auditor.py`.
+- Cross-component and HTTP workflows: integration and ASGI suites.
+- Stable outputs and imports: characterization, public API, and architecture suites.
+
+Constraint volume grows with courses, candidate slots, faculty, and cross-course pairs. Keep bounded diagnostic
+searches explicit and preserve the candidate-comparison caps when extending preflight analysis.

--- a/fern/docs/pages/dev/testing.mdx
+++ b/fern/docs/pages/dev/testing.mdx
@@ -1,42 +1,63 @@
 ---
 title: Testing
-description: pytest layout, coverage, and slow markers for the scheduler codebase.
+description: Unit, integration, characterization, documentation, coverage, and marker conventions.
 ---
 
-## Run tests
-
-From the repository root with dev dependencies:
+## Run the complete suite
 
 ```bash
 uv sync
 uv run pytest
 ```
 
-## Layout
+`pyproject.toml` enables branch coverage for `scheduler` and requires at least 75% total coverage.
 
-- **`tests/`** — Pytest modules mirroring features (config, scheduler, server, etc.).
-- **`tests/conftest.py`** — Shared fixtures and hooks.
-- **`tests/fixtures/`** — JSON configs such as **`minimal_config.json`**.
+## Test layers
 
-## Coverage
+- Focused unit tests cover configuration, models, time-slot generation, normalized problems, solver constraints,
+  diagnostics, auditing, writers, and server helpers.
+- `@pytest.mark.integration` covers cross-component solver and HTTP boundaries.
+- `@pytest.mark.characterization` compares stable public schedules, diagnoses, audits, serialization, imports, and
+  signatures against golden compatibility artifacts.
+- `@pytest.mark.slow` is reserved for the full `example.json` and genuinely long solver paths.
+- Architecture tests enforce Z3-free layers and façade delegation.
+- Documentation tests enforce complete public docstrings, datatype fields, Fern generation, and narrative parity.
 
-`pyproject.toml` enables **`--cov=scheduler`** with a **75%** minimum line coverage (`--cov-fail-under=75`). Keep new code exercised.
+Shared fixtures live in `tests/conftest.py`; reusable configuration builders live in `tests/scenario_builders.py`;
+golden data lives under `tests/fixtures/characterization/`.
 
-## Markers
-
-**`@pytest.mark.slow`** — Reserved for tests that load large configs (e.g. full `example.json`) or long solver runs. Run the fast subset:
+## Useful subsets
 
 ```bash
-uv run pytest -m "not slow"
+uv run pytest -m "not integration and not slow" --no-cov
+uv run pytest -m "integration and not slow" --no-cov
+uv run pytest -m characterization --no-cov
+uv run pytest -m slow --no-cov
 ```
 
-## CI parity
+Keep the normal `uv run pytest` invocation as the acceptance command because it applies the coverage gate.
 
-Install **prek** hooks to mirror CI locally:
+## Documentation checks
+
+After public APIs, configuration, routes, docstrings, or narrative docs change:
+
+```bash
+uv run python scripts/export_openapi.py
+uv run python scripts/export_config_schema.py
+fern docs md generate --local --library scheduler-python
+fern check --warnings
+```
+
+OpenAPI and the configuration schema are tracked and must be deterministic. The Fern Python library output is an
+ignored build artifact.
+
+## CI parity
 
 ```bash
 uv run prek install
 uv run prek run --all-files
+git diff --check
 ```
 
-Also run **`ruff`** and **`ty`** as in **`CONTRIBUTING.md`**.
+The hook suite runs Ruff and ty in addition to repository hygiene checks. CI runs the full test suite on every
+supported Python version.

--- a/fern/docs/pages/python/overview.mdx
+++ b/fern/docs/pages/python/overview.mdx
@@ -1,17 +1,20 @@
 ---
 title: Using the Python library
-description: Load CombinedConfig, run Scheduler, and export schedules — plus important type naming notes.
+description: Validate configuration, enumerate schedules, diagnose feasibility, audit results, and export output.
 ---
 
 ## Install
-
-Use the same package as the CLI (see **Introduction → Welcome**):
 
 ```bash
 pip install course-constraint-scheduler
 ```
 
-## Minimal flow
+The package requires Python 3.12 or newer. The distribution name is `course-constraint-scheduler`; the import name
+is `scheduler`.
+
+## Load and validate configuration
+
+Use `load_config_from_file` when invalid JSON or configuration should raise its normal exception:
 
 ```python
 from scheduler import Scheduler, load_config_from_file
@@ -19,20 +22,88 @@ from scheduler.config import CombinedConfig
 
 config = load_config_from_file(CombinedConfig, "config.json")
 scheduler = Scheduler(config)
+```
 
+It can raise `OSError`, `json.JSONDecodeError`, or `pydantic.ValidationError`. For an untrusted in-memory mapping,
+use the non-throwing structured validator:
+
+```python
+from scheduler import validate_combined_config_data
+
+validation = validate_combined_config_data(payload)
+if not validation.is_valid:
+    for finding in validation.diagnostics:
+        print(finding.code, finding.path, finding.message)
+```
+
+Valid input includes a stable `configuration_fingerprint`. See **Diagnostics and auditing** for the validation
+contract.
+
+## Construct a scheduler
+
+```python
+scheduler = Scheduler(config, solver_timeout_ms=30_000)
+```
+
+`solver_timeout_ms` is optional for Python callers and applies to each Z3 check performed by generation or
+diagnosis. `None` leaves Z3 without a scheduler-supplied timeout. The REST server always supplies its configured
+API timeout.
+
+Construction normalizes the problem and builds hard constraints, but schedules are generated lazily.
+
+## Enumerate schedules
+
+```python
 for schedule in scheduler.get_models():
     for course_instance in schedule:
         print(course_instance.as_csv())
 ```
 
-If you are working from this repository, start with `example.json` for a richer scenario or `tests/fixtures/minimal_config.json` for a smaller fixture.
+`get_models()` returns a generator of complete `list[CourseInstance]` schedules. It stops when it reaches the
+configuration's `limit`, exhausts the solution space, or receives `unknown` from Z3. Each result is blocked before
+the next check, so one generator yields distinct schedules in deterministic model-blocking order. Calling
+`get_models()` again creates a fresh enumeration.
 
-- **`load_config_from_file`** — JSON from disk into any Pydantic model (usually `CombinedConfig`).
-- **`Scheduler`** — Builds the Z3 problem once; **`get_models()`** is a generator yielding each feasible schedule as a list of **`CourseInstance`** objects.
+Z3 construction, optimization, or evaluation failures can raise `z3.Z3Exception`.
+
+## Diagnose before generation
+
+```python
+diagnosis = scheduler.diagnose()
+if diagnosis.status == "unsatisfiable":
+    for rule in diagnosis.conflicting_constraints:
+        print(rule.code, rule.locations, rule.message)
+```
+
+`diagnose()` checks hard-constraint feasibility without running soft objectives or changing enumeration. The
+returned `ScheduleDiagnosis` includes candidate domains, capacity and day analysis, preflight findings, unsat
+cores, supporting facts, suggestions, verified repairs, provenance, completeness metadata, fingerprint, timing,
+and timeout information.
+
+## Audit a schedule
+
+```python
+schedule = next(scheduler.get_models())
+audit = scheduler.audit_schedule(schedule)
+if not audit.is_valid:
+    for violation in audit.constraint_violations:
+        print(violation.message)
+```
+
+`audit_schedule()` does not query Z3. The independent auditor validates the supplied decoded schedule against normalized policies
+and reports workload, resource use, enabled objective scores, and unmet preference outcomes. Unknown faculty names
+can raise `KeyError` while preference scoring is enabled.
+
+## Diagnostic contracts
+
+The root package exports the stable solver-independent contracts used by validation, diagnosis, and auditing,
+including `ConfigurationValidationResult`, `ScheduleDiagnosis`, `ConstraintDiagnostic`, `RepairSetDiagnostic`,
+`ScheduleAudit`, `FacultyWorkloadDiagnostic`, and `ObjectiveScoreDiagnostic`. Their complete field documentation is
+available under **Reference**.
 
 ## Writers
 
-JSON and CSV serializers live under **`scheduler.writers`**.
+JSON and CSV serializers live under `scheduler.writers`:
 
 ```python
 from scheduler.writers import CSVWriter, JSONWriter
@@ -43,24 +114,23 @@ with JSONWriter("schedules.json") as json_writer, CSVWriter("schedules.csv") as 
         csv_writer.add_schedule(schedule)
 ```
 
-Use writers when you need stable machine-readable output files instead of printing rows directly.
-
 ## Naming: two different `Course` concepts
 
-- **`scheduler.config`** exports a **`Course` type alias** — a **string** course id used in JSON (`course_id`, preferences, conflicts).
-- **`scheduler.models`** defines a **`Course` class** — meeting structure with credits and `course_id`.
-
-Objects from **`get_models()`** are **`CourseInstance`**; the embedded model course is **`.course`**. Use **`.course.course_id`** when you need the config-style id string.
+- `scheduler.config.Course` is a string course-id type alias used by JSON configuration.
+- `scheduler.models.Course` is the runtime class containing credits, section identity, and compatibility mirrors.
+- Generated values are `CourseInstance`; use `.course.course_id` for the base configuration id.
 
 ## Full API surface
 
-See **Reference** for Fern-generated pages covering the public modules, classes, functions, methods, parameters,
-and cross-linked types under `scheduler`.
+See **Reference** for Fern-generated pages covering importable modules, public callables, parameters, exceptions,
+execution semantics, and datatype fields. `Scheduler` is the stable façade; `SchedulingProblem`, `SolverEngine`,
+`DiagnosticEngine`, and `ScheduleAuditor` are internal architectural components despite being importable from their
+implementation modules.
 
 ## Local regeneration
 
-After changing a public API or docstring, regenerate the reference from the checked-out source before
-`fern docs dev`. Fern's local library parser requires Docker:
+After changing a public API or docstring, regenerate the ignored reference from the checked-out source. Fern's
+local library parser requires Node.js 22 and Docker:
 
 ```bash
 npm install -g fern-api@5.75.4

--- a/fern/docs/pages/rest/quickstart.mdx
+++ b/fern/docs/pages/rest/quickstart.mdx
@@ -1,65 +1,20 @@
 ---
-title: REST API quickstart
-description: Submit a config, iterate generated schedules, and manage session lifecycle from the HTTP API.
+title: REST API integration
+description: Validate input, manage schedule sessions, generate models, diagnose feasibility, audit results, and clean up.
 ---
 
-The REST API is session-based. You submit a configuration once, receive a `schedule_id`, then use that id to generate and inspect schedules.
+The REST API stores sessions in one process's memory. Submit a configuration once, receive a `schedule_id`, and use
+that id for generation, diagnosis, auditing, and lifecycle operations.
 
 ## Start the server
 
 ```bash
-scheduler-server --port 8000 --host 0.0.0.0 --log-level info
+scheduler-server --port 8000 --host 0.0.0.0 --log-level info --workers 16
 ```
 
-Interactive docs are available at `http://localhost:8000/docs/`.
-
-## 1) Submit a configuration
-
-```bash
-curl -X POST "http://localhost:8000/submit" \
-  -H "Content-Type: application/json" \
-  -d @example.json
-```
-
-Example response:
-
-```json
-{
-  "schedule_id": "f9f2c906-5a00-4b78-a0dd-31f3240fbf4b",
-  "endpoint": "/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b"
-}
-```
-
-The `schedule_id` is the key for all follow-up requests.
-
-## 2) Generate schedules
-
-```bash
-curl -X POST "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/next"
-```
-
-- Call `next` repeatedly to enumerate feasible schedules.
-- Once generation is exhausted, the endpoint returns an error indicating no additional schedules are available.
-
-## 3) Inspect progress and existing schedules
-
-```bash
-curl -X GET "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/count"
-curl -X GET "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/index/0"
-curl -X GET "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/details"
-curl -X GET "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/diagnosis"
-curl -X GET "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/audit/0"
-curl -X GET "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/status"
-```
-
-Useful endpoints:
-
-- `count`: Current generated count, configured limit, completion status.
-- `index/{index}`: Retrieve a previously generated schedule by index.
-- `details`: Return the original combined config plus generation metadata.
-- `diagnosis`: Check hard-constraint feasibility. It returns source paths, a configuration fingerprint, candidate domains and rejected patterns, workload/resource capacity checks, provenance edges, subset-minimal unsat cores, bounded alternative cores, and solver-verified rule-level repair sets. `unknown` responses include the solver reason, elapsed time, and configured timeout.
-- `audit/{index}`: Independently verify one generated schedule, including hard-rule compliance, faculty workloads, room/lab use, enabled objective scores, and unmet preference/objective outcomes.
-- `status`: Report initialization/background generation state, completion or failure reason, generated-model count, enumeration scope (exhausted or request-bounded), idle TTL, and active API resource limits.
+`--workers` controls the shared Z3 thread pool, not Uvicorn processes. The server always runs one Uvicorn process,
+because sessions are not shared across processes. Interactive OpenAPI documentation is available at
+`http://localhost:8000/docs/`.
 
 ## Validate before submitting
 
@@ -69,41 +24,154 @@ curl -X POST "http://localhost:8000/validate" \
   -d @example.json
 ```
 
-Unlike `/submit`, this endpoint always returns a structured validation result. Each invalid field has a stable code and JSON Pointer path; a valid payload returns its configuration fingerprint.
+Configuration failures return a structured `200` response with `is_valid: false`, stable diagnostic codes, and
+JSON Pointer paths. Valid input returns its canonical configuration fingerprint. `/validate` does not create a
+session, consume session capacity, or invoke Z3. A body that is not a JSON object can still be rejected by FastAPI
+with `422` before configuration validation runs.
 
-## Optional: background generation
+## Submit a configuration
+
+```bash
+curl -X POST "http://localhost:8000/submit" \
+  -H "Content-Type: application/json" \
+  -d @example.json
+```
+
+```json
+{
+  "schedule_id": "f9f2c906-5a00-4b78-a0dd-31f3240fbf4b",
+  "endpoint": "/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b"
+}
+```
+
+Scheduler construction is queued in the shared solver executor. Follow-up operations await initialization when
+they require the scheduler. Failed initialization removes the session and returns `422`.
+
+## Generate schedules
+
+```bash
+curl -X POST "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/next"
+```
+
+`next` generates, retains, and returns one schedule. Generated indices are zero-based and append-only. Reaching the
+requested limit or exhausting the solution space returns `400`; unexpected generation failures return `500`.
+
+To enumerate the remainder in the background:
 
 ```bash
 curl -X POST "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/generate_all"
 ```
 
-This starts background generation for all remaining schedules.
+The response confirms the current and target count without waiting for generation. At most one background run is
+active per session. While it is active, another `generate_all` or `next` returns `409 Conflict`. A single session
+lock serializes generator advancement, diagnosis, and auditing; diagnosis and auditing wait for the lock rather
+than returning a generation-conflict response.
 
-Only one generation operation may run for a session. While `generate_all` is active, another `generate_all` call or a `next` call returns `409 Conflict`.
+## Inspect and explain
 
-## Cleanup
+```bash
+curl "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/count"
+curl "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/status"
+curl "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/index/0"
+curl "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/details"
+curl "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/diagnosis"
+curl "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/audit/0"
+```
+
+- `count` is a non-blocking count and completion snapshot.
+- `status` reports initialization/background state, counts, terminal reason, enumeration scope, idle age, TTL, and
+  active server limits.
+- `index/{index}` returns a retained schedule without advancing generation.
+- `details` returns the submitted `CombinedConfig`, session id, and current generated count.
+- `diagnosis` checks hard feasibility without consuming a model.
+- `audit/{index}` independently validates and scores an existing retained model.
+
+See **Diagnostics and auditing** for the diagnostic and audit contracts.
+
+### Session status values
+
+`state` is `initializing`, `generating`, `ready`, or `complete`. `background_state` is `not_started`, `running`,
+`cancelled`, `failed`, or `completed`.
+
+Terminal `completion_reason` values include `requested_schedule_limit_reached`, `solution_space_exhausted`,
+`generation_error`, `background_generation_cancelled`, and `background_generation_failed`. `enumeration_scope` is
+`exhausted` only after proven solution-space exhaustion; otherwise it is `bounded_by_requested_limit`.
+
+## Endpoint inventory
+
+| Method | Path | Behavior |
+|---|---|---|
+| `POST` | `/validate` | Validate raw JSON without creating a session. |
+| `POST` | `/submit` | Queue scheduler initialization and create a session. |
+| `GET` | `/schedules/{schedule_id}/details` | Return submitted configuration and retained count. |
+| `GET` | `/schedules/{schedule_id}/diagnosis` | Diagnose hard-constraint feasibility. |
+| `GET` | `/schedules/{schedule_id}/audit/{index}` | Audit one retained decoded model. |
+| `POST` | `/schedules/{schedule_id}/next` | Generate and retain one model. |
+| `POST` | `/schedules/{schedule_id}/generate_all` | Start one background enumeration task. |
+| `GET` | `/schedules/{schedule_id}/count` | Return count and completion snapshot. |
+| `GET` | `/schedules/{schedule_id}/status` | Return operational state and active limits. |
+| `GET` | `/schedules/{schedule_id}/index/{index}` | Return one retained serialized model. |
+| `DELETE` | `/schedules/{schedule_id}/delete` | Queue deletion after the response; unknown ids return `404`. |
+| `POST` | `/schedules/{schedule_id}/cleanup` | Remove immediately; the operation is idempotent. |
+| `GET` | `/health` | Return process responsiveness and active-session count. |
+
+The generated **REST API reference** contains every request and response schema.
+
+## Cleanup and expiry
+
+Deferred deletion:
 
 ```bash
 curl -X DELETE "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/delete"
 ```
 
-Sessions are stored in-memory and are not shared across processes. Restarting the server clears active sessions. Idle sessions expire automatically (30 minutes by default).
+Immediate, idempotent cleanup:
+
+```bash
+curl -X POST "http://localhost:8000/schedules/f9f2c906-5a00-4b78-a0dd-31f3240fbf4b/cleanup"
+```
+
+Cleanup removes the session and requests cancellation of queued initialization or background generation. Work
+already running in a solver thread may finish internally, but the session is no longer addressable.
+
+Idle sessions expire after 30 minutes by default. Active initialization and background generation are not reaped.
+The lifespan-managed reaper checks at least once per minute, or more frequently when the configured TTL is shorter.
+Restarting the process clears every session.
 
 ## Built-in request limits
 
-The server provides defensive limits for unauthenticated deployments. Override these environment variables to match your capacity:
+Environment values must be positive integers. Missing, invalid, and non-positive values fall back to the defaults.
 
 | Variable | Default | Purpose |
 |---|---:|---|
-| `SCHEDULER_API_MAX_ACTIVE_SESSIONS` | 16 | In-memory sessions allowed at once. |
-| `SCHEDULER_API_MAX_COURSES` | 100 | Courses accepted in one request. |
-| `SCHEDULER_API_MAX_SCHEDULES` | 100 | Maximum requested schedules per session. |
-| `SCHEDULER_API_MAX_CANDIDATE_SLOTS` | 10,000 | Upper bound on estimated generated time-slot candidates. |
-| `SCHEDULER_API_SOLVER_TIMEOUT_MS` | 30,000 | Z3 timeout for each solve check. |
+| `SCHEDULER_API_MAX_ACTIVE_SESSIONS` | 16 | In-memory sessions retained concurrently. |
+| `SCHEDULER_API_MAX_COURSES` | 100 | Courses accepted in one submitted configuration. |
+| `SCHEDULER_API_MAX_SCHEDULES` | 100 | Maximum requested `limit` for an API session. |
+| `SCHEDULER_API_MAX_CANDIDATE_SLOTS` | 10,000 | Bounded arithmetic preflight estimate of generated time-slot candidates. |
+| `SCHEDULER_API_SOLVER_TIMEOUT_MS` | 30,000 | Timeout applied to each API Z3 check. |
 | `SCHEDULER_API_SESSION_TTL_SECONDS` | 1,800 | Idle-session lifetime. |
 
-Requests that exceed a per-request limit return `422`; a full active-session pool returns `429`. These controls complement, rather than replace, reverse-proxy authentication and rate limiting.
+Course, requested-schedule, and candidate-slot limits return `422`. A full active-session pool returns `429`.
+These limits apply only to the REST server; CLI and direct Python callers remain bounded only by configuration and
+their own resources.
 
-## Request/response schema
+## Common HTTP failures
 
-The `POST /submit` request body matches `CombinedConfig` (same as CLI and Python API). The full endpoint contract is available under **REST API reference** in the sidebar.
+| Status | Meaning |
+|---:|---|
+| `400` | Generation reached its limit/solution-space end, or request setup failed. |
+| `404` | Session or retained schedule index was not found. |
+| `408` | Lazy generator initialization was cancelled. |
+| `409` | A conflicting background generation operation is active. |
+| `422` | Request validation, API limits, or asynchronous scheduler initialization failed. |
+| `429` | Active-session capacity is full. |
+| `500` | Unexpected scheduler, generator, or background failure. |
+
+## Deployment and security
+
+The server has no built-in authentication. Put internet-facing deployments behind a trusted reverse proxy, API
+gateway, or private network and apply authentication and rate limiting there.
+
+Set `CORS_ORIGINS` to a comma-separated allowlist when credentialed browser requests are needed. When unset, the
+server allows all origins without credentials. Do not run multiple independent server processes if callers expect
+to retrieve in-memory sessions through an arbitrary process.

--- a/fern/docs/pages/welcome.mdx
+++ b/fern/docs/pages/welcome.mdx
@@ -69,5 +69,6 @@ The repository includes [`example.json`](https://github.com/mucsci/scheduler/blo
 ## Next steps
 
 - **Configuration** — JSON format for rooms, courses, faculty, time slots, limits, and optimizer flags.
+- **Concepts** — exact hard rules, objectives, validation, diagnosis, repairs, and auditing.
 - **REST API** — session-based HTTP API for web integrations.
 - **Development** — extending constraints, config, tests, and contributions.

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -695,7 +695,7 @@
                 "type": "null"
               }
             ],
-            "description": "Specific start time constraint"
+            "description": "Fixed start fallback for meetings without their own start time"
           }
         },
         "additionalProperties": false,
@@ -983,7 +983,7 @@
         "properties": {
           "course_id": {
             "$ref": "#/components/schemas/Course",
-            "description": "Unique identifier for the course",
+            "description": "Base course identifier; repeated values create separately numbered sections",
             "example": "CS 101"
           },
           "credits": {
@@ -1011,7 +1011,7 @@
             },
             "type": "array",
             "title": "Lab",
-            "description": "List of acceptable lab names",
+            "description": "Acceptable labs; an empty list means the course has no lab meeting",
             "example": [
               "Lab 101"
             ]
@@ -1022,7 +1022,7 @@
             },
             "type": "array",
             "title": "Conflicts",
-            "description": "List of course IDs that cannot be scheduled simultaneously"
+            "description": "Base course IDs whose sections cannot overlap; an empty list means no declared conflicts"
           },
           "faculty": {
             "anyOf": [
@@ -1037,7 +1037,7 @@
               }
             ],
             "title": "Faculty",
-            "description": "Faculty candidates, or null to derive candidates from faculty course preferences",
+            "description": "Non-empty faculty candidates, or null to derive candidates from faculty course-preference keys",
             "example": [
               "Dr. Smith"
             ]
@@ -1053,13 +1053,13 @@
           "faculty"
         ],
         "title": "CourseConfig",
-        "description": "Represents a course configuration.\n\n**Usage:**\n```python\nCourseConfig(course_id=\"CS 101\", credits=3, room=[...], lab=[...], conflicts=[], faculty=[])\n```"
+        "description": "Represents a course configuration.\n\n**Usage:**\n```python\nCourseConfig(\n    course_id=\"CS 101\",\n    credits=3,\n    room=[\"Room 101\"],\n    lab=[],\n    conflicts=[],\n    faculty=[\"Dr. Smith\"],\n)\n```"
       },
       "CourseConfig-Output": {
         "properties": {
           "course_id": {
             "$ref": "#/components/schemas/Course",
-            "description": "Unique identifier for the course"
+            "description": "Base course identifier; repeated values create separately numbered sections"
           },
           "credits": {
             "type": "integer",
@@ -1086,7 +1086,7 @@
             },
             "type": "array",
             "title": "Lab",
-            "description": "List of acceptable lab names",
+            "description": "Acceptable labs; an empty list means the course has no lab meeting",
             "example": [
               "Lab 101"
             ]
@@ -1097,7 +1097,7 @@
             },
             "type": "array",
             "title": "Conflicts",
-            "description": "List of course IDs that cannot be scheduled simultaneously"
+            "description": "Base course IDs whose sections cannot overlap; an empty list means no declared conflicts"
           },
           "faculty": {
             "anyOf": [
@@ -1112,7 +1112,7 @@
               }
             ],
             "title": "Faculty",
-            "description": "Faculty candidates, or null to derive candidates from faculty course preferences",
+            "description": "Non-empty faculty candidates, or null to derive candidates from faculty course-preference keys",
             "example": [
               "Dr. Smith"
             ]
@@ -1128,7 +1128,7 @@
           "faculty"
         ],
         "title": "CourseConfig",
-        "description": "Represents a course configuration.\n\n**Usage:**\n```python\nCourseConfig(course_id=\"CS 101\", credits=3, room=[...], lab=[...], conflicts=[], faculty=[])\n```"
+        "description": "Represents a course configuration.\n\n**Usage:**\n```python\nCourseConfig(\n    course_id=\"CS 101\",\n    credits=3,\n    room=[\"Room 101\"],\n    lab=[],\n    conflicts=[],\n    faculty=[\"Dr. Smith\"],\n)\n```"
       },
       "CourseInstanceResponse": {
         "properties": {
@@ -1318,7 +1318,7 @@
             },
             "type": "object",
             "title": "Times",
-            "description": "Dictionary mapping day names to time ranges",
+            "description": "Availability ranges keyed by weekday; omitted days and empty lists mean unavailable",
             "example": {
               "MON": [
                 "10:00-12:00"
@@ -1444,7 +1444,7 @@
             },
             "type": "object",
             "title": "Times",
-            "description": "Dictionary mapping day names to time ranges",
+            "description": "Availability ranges keyed by weekday; omitted days and empty lists mean unavailable",
             "example": {
               "MON": [
                 "10:00-12:00"
@@ -1662,7 +1662,7 @@
                 "type": "null"
               }
             ],
-            "description": "Specific start time constraint"
+            "description": "Fixed start for this meeting; overrides the containing pattern start time"
           },
           "duration": {
             "type": "integer",
@@ -1674,7 +1674,7 @@
           "lab": {
             "type": "boolean",
             "title": "Lab",
-            "description": "Whether the meeting is in a lab",
+            "description": "Whether this is the pattern's single lab meeting",
             "default": false
           }
         },
@@ -2316,7 +2316,7 @@
           "reason"
         ],
         "title": "ScheduleDiagnosisResponse",
-        "description": "Structured hard-constraint feasibility analysis for a schedule session.\n\nFields:\n    schedule_id: Session whose configuration was diagnosed.\n    status: Solver feasibility status such as sat, unsat, or unknown.\n    conflicting_constraints: Minimal primary set of conflicting hard rules.\n    alternative_conflict_sets: Other independently discovered conflict cores.\n    supporting_facts: Relevant non-core facts that explain the conflict.\n    relaxation_suggestions: Ranked configuration changes derived from findings.\n    repair_sets: Solver-verified combinations of relaxations.\n    candidate_domains: Per-course candidate resources and eliminations.\n    capacity_analysis: Necessary resource and workload capacity calculations.\n    day_feasibility: Per-faculty, per-day availability feasibility facts.\n    preflight_findings: Static contradictions found before core extraction.\n    provenance: Edges linking facts, configuration, and conclusions.\n    configuration_fingerprint: Stable digest of the diagnosed configuration.\n    core_is_minimal: Whether the primary conflict core was proven minimal.\n    alternative_cores_complete: Whether alternative-core enumeration completed.\n    repair_sets_complete: Whether repair-set enumeration completed.\n    diagnostic_completeness: Overall completeness classification.\n    diagnostic_version: Version of the diagnostic response semantics.\n    elapsed_ms: Total diagnostic execution time in milliseconds.\n    solver_timeout_ms: Solver timeout used, or null when no timeout was set.\n    reason: Solver or diagnostic explanation for an indeterminate result."
+        "description": "Structured hard-constraint feasibility analysis for a schedule session.\n\nFields:\n    schedule_id: Session whose configuration was diagnosed.\n    status: Solver feasibility status: satisfiable, unsatisfiable, or unknown.\n    conflicting_constraints: Minimal primary set of conflicting hard rules.\n    alternative_conflict_sets: Other independently discovered conflict cores.\n    supporting_facts: Relevant non-core facts that explain the conflict.\n    relaxation_suggestions: Ranked configuration changes derived from findings.\n    repair_sets: Solver-verified combinations of relaxations.\n    candidate_domains: Per-course candidate resources and eliminations.\n    capacity_analysis: Necessary resource and workload capacity calculations.\n    day_feasibility: Per-faculty, per-day availability feasibility facts.\n    preflight_findings: Static contradictions found before core extraction.\n    provenance: Edges linking facts, configuration, and conclusions.\n    configuration_fingerprint: Stable digest of the diagnosed configuration.\n    core_is_minimal: Whether the primary conflict core was proven minimal.\n    alternative_cores_complete: Whether alternative-core enumeration completed.\n    repair_sets_complete: Whether repair-set enumeration completed.\n    diagnostic_completeness: Overall completeness classification.\n    diagnostic_version: Version of the diagnostic response semantics.\n    elapsed_ms: Total diagnostic execution time in milliseconds.\n    solver_timeout_ms: Solver timeout used, or null when no timeout was set.\n    reason: Solver or diagnostic explanation for an indeterminate result."
       },
       "ScheduleResponse": {
         "properties": {
@@ -2811,7 +2811,7 @@
             },
             "type": "object",
             "title": "Times",
-            "description": "Dictionary mapping day names to time blocks"
+            "description": "Time blocks keyed by weekday; every Monday-Friday list must be non-empty"
           },
           "classes": {
             "items": {
@@ -2819,14 +2819,14 @@
             },
             "type": "array",
             "title": "Classes",
-            "description": "List of class patterns"
+            "description": "Meeting patterns; at least one pattern must be enabled"
           },
           "max_time_gap": {
             "type": "integer",
             "minimum": 0.0,
             "exclusiveMinimum": 0.0,
             "title": "Max Time Gap",
-            "description": "Maximum time gap between time slots to determine if they are adjacent",
+            "description": "Maximum gap in minutes used to determine whether meetings are adjacent",
             "default": 30,
             "example": 30
           },
@@ -2834,7 +2834,7 @@
             "type": "integer",
             "exclusiveMinimum": 0.0,
             "title": "Min Time Overlap",
-            "description": "Minimum overlap between time slots",
+            "description": "Minimum clock-time overlap in minutes between meetings on different pattern days",
             "default": 45,
             "example": 45
           }
@@ -2862,7 +2862,7 @@
             },
             "type": "object",
             "title": "Times",
-            "description": "Dictionary mapping day names to time blocks"
+            "description": "Time blocks keyed by weekday; every Monday-Friday list must be non-empty"
           },
           "classes": {
             "items": {
@@ -2870,14 +2870,14 @@
             },
             "type": "array",
             "title": "Classes",
-            "description": "List of class patterns"
+            "description": "Meeting patterns; at least one pattern must be enabled"
           },
           "max_time_gap": {
             "type": "integer",
             "minimum": 0.0,
             "exclusiveMinimum": 0.0,
             "title": "Max Time Gap",
-            "description": "Maximum time gap between time slots to determine if they are adjacent",
+            "description": "Maximum gap in minutes used to determine whether meetings are adjacent",
             "default": 30,
             "example": 30
           },
@@ -2885,7 +2885,7 @@
             "type": "integer",
             "exclusiveMinimum": 0.0,
             "title": "Min Time Overlap",
-            "description": "Minimum overlap between time slots",
+            "description": "Minimum clock-time overlap in minutes between meetings on different pattern days",
             "default": 45,
             "example": 45
           }

--- a/skills/sched-domain-z3-config/SKILL.md
+++ b/skills/sched-domain-z3-config/SKILL.md
@@ -2,15 +2,19 @@
 name: sched-domain-z3-config
 description: >-
   Implements or debugs scheduling logic, Z3 constraints, and JSON configuration
-  for the course constraint scheduler. Use when working in scheduler.py,
-  config models, time slots, or solver behavior.
+  for the course constraint scheduler. Use when working in normalized problems,
+  solver/diagnostic/audit engines, config models, time slots, or solver behavior.
 ---
 
 # Domain: Z3, config, models
 
 ## Core files
 
-- **`src/scheduler/scheduler.py`**: Z3 problem construction, solving, optimization flags.
+- **`src/scheduler/problem.py`**: Z3-free normalized policies, time domains, provenance paths, and cached queries.
+- **`src/scheduler/solver.py`**: Z3 context, symbols, constraints, objectives, decoding, and enumeration.
+- **`src/scheduler/diagnostics.py`**: Preflight facts, cores, provenance, suggestions, and verified repairs.
+- **`src/scheduler/audit.py`**: Independent hard-rule validation and objective scoring.
+- **`src/scheduler/scheduler.py`**: Stable public façade and compatibility re-exports; keep it orchestration-only.
 - **`src/scheduler/config.py`**: Pydantic models, validation, loading (`CombinedConfig`, etc.).
 - **`src/scheduler/time_slot_generator.py`**: Time slot generation utilities.
 - **`src/scheduler/models/`**: Runtime schedule representations (`CourseInstance`, `TimeSlot`, ...).
@@ -31,3 +35,5 @@ When touching types or docs, preserve this distinction to avoid breaking configs
 
 - Prefer clear, testable encodings; watch performance on large inputs.
 - Respect existing **caching** patterns; do not remove `@cache` on hot paths without analysis (Ruff **B019** is suppressed on intentional method caches).
+- Track each actionable hard rule with a granular `DiagnosticConstraintArtifact`, then mirror it independently in
+  `ScheduleAuditor` and document it under Fern's **Scheduling rules and objectives** page.

--- a/skills/sched-fastapi-server/SKILL.md
+++ b/skills/sched-fastapi-server/SKILL.md
@@ -29,6 +29,8 @@ uv run python scripts/export_openapi.py
 2. Regenerate OpenAPI with `uv run python scripts/export_openapi.py`.
 3. Run validation (`uv run pytest` and/or focused API tests).
 4. Update Fern narrative docs in `fern/docs/pages/` when user-facing behavior changed.
+5. Keep every application route in the endpoint inventory at `fern/docs/pages/rest/quickstart.mdx`; the
+   source-driven documentation parity test will reject omissions.
 
 ## Integration tests
 
@@ -37,6 +39,8 @@ uv run python scripts/export_openapi.py
 ## Documentation
 
 - User-facing API narrative lives under **`fern/docs/pages/`**; machine-readable spec is **`fern/openapi.json`**.
+  Session states, completion reasons, concurrency, cleanup, limits, TTL, CORS, authentication expectations, and
+  error statuses belong in the REST integration guide when those behaviors change.
 
 Cross-skill references:
 

--- a/skills/sched-fern-openapi-docs/SKILL.md
+++ b/skills/sched-fern-openapi-docs/SKILL.md
@@ -31,7 +31,14 @@ Quick decision guide:
 ## Authoring
 
 - **Guides / prose**: `fern/docs/pages/` (MDX), navigation in `fern/docs.yml`.
+- **Behavior contracts**: keep `concepts/scheduling-rules.mdx` aligned with solver/auditor rules and
+  `concepts/diagnostics-auditing.mdx` aligned with diagnostic contracts and search bounds.
 - **Site config**: `fern/fern.config.json`, `fern/generators.yml`.
+- **Parity enforcement**: `tests/test_documentation_parity.py` discovers config fields, FastAPI routes, façade
+  methods, compatibility exports, API environment limits, architecture claims, and canonical examples.
+
+Use `tests/fixtures/minimal_config.json` and `example.json` as the complete validated examples. Do not copy another
+full configuration into MDX or README unless a test parses and validates that copy.
 
 ## Local preview
 

--- a/skills/sched-json-types/SKILL.md
+++ b/skills/sched-json-types/SKILL.md
@@ -15,8 +15,9 @@ description: >-
 
 ## Role
 
-- Central place for **JSON structure typing** used across parsing, API, and docs.
-- Keep **`TypedDict`** / aliases aligned with **Pydantic** models in **`config.py`** and FastAPI schemas.
+- Supplemental **TypedDict** descriptions for JSON-shaped values used by callers and writers.
+- Runtime configuration and REST validation remain authoritative in Pydantic models from **`config.py`** and
+  **`server.py`**; do not treat duplicated TypedDicts as runtime schema.
 
 ## Practices
 

--- a/skills/sched-testing-pytest/SKILL.md
+++ b/skills/sched-testing-pytest/SKILL.md
@@ -19,10 +19,15 @@ uv run pytest
 
 ## Markers
 
-- **`@pytest.mark.slow`**: Heavy tests (e.g. full `example.json`, long solver paths). Use for anything that would slow routine `pytest` runs; document in the test docstring when appropriate.
+- **`@pytest.mark.integration`**: Cross-component solver or HTTP boundary tests.
+- **`@pytest.mark.characterization`**: Golden public compatibility outputs and signatures.
+- **`@pytest.mark.slow`**: Heavy tests (e.g. full `example.json`, long solver paths).
 
 ## Conventions
 
 - Shared fixtures: `tests/conftest.py`.
+- Reusable config builders: `tests/scenario_builders.py`; golden outputs: `tests/fixtures/characterization/`.
 - Prefer testing **public behavior** of `scheduler` modules; reach into internals only when necessary for Z3 or config edge cases.
 - After behavior changes, update or add tests near related modules under `tests/`.
+- Keep source-driven docs coverage in `tests/test_documentation_parity.py` aligned with new configuration fields,
+  façade methods, routes, environment limits, and canonical examples.

--- a/src/scheduler/config.py
+++ b/src/scheduler/config.py
@@ -350,9 +350,12 @@ class Meeting(StrictBaseModel):
     Day of the week
     """
 
-    start_time: TimeString | None = Field(default=None, description="Specific start time constraint")
+    start_time: TimeString | None = Field(
+        default=None,
+        description="Fixed start for this meeting; overrides the containing pattern start time",
+    )
     """
-    Specific start time constraint
+    Fixed meeting start that takes precedence over the containing pattern start
     """
 
     duration: PositiveInt = Field(description="Duration of the meeting in minutes", json_schema_extra={"example": 150})
@@ -360,9 +363,9 @@ class Meeting(StrictBaseModel):
     Duration of the meeting in minutes
     """
 
-    lab: bool = Field(default=False, description="Whether the meeting is in a lab")
+    lab: bool = Field(default=False, description="Whether this is the pattern's single lab meeting")
     """
-    Whether the meeting is in a lab
+    Whether this meeting is the pattern's single lab meeting
     """
 
 
@@ -394,9 +397,12 @@ class ClassPattern(StrictBaseModel):
     Whether the pattern is disabled
     """
 
-    start_time: TimeString | None = Field(default=None, description="Specific start time constraint")
+    start_time: TimeString | None = Field(
+        default=None,
+        description="Fixed start fallback for meetings without their own start time",
+    )
     """
-    Specific start time constraint
+    Fixed start used by meetings that do not specify their own start
     """
 
     @field_validator("meetings", mode="after")
@@ -439,34 +445,36 @@ class TimeSlotConfig(StrictBaseModel):
     ```
     """
 
-    times: dict[Day, list[TimeBlock]] = Field(description="Dictionary mapping day names to time blocks")
+    times: dict[Day, list[TimeBlock]] = Field(
+        description="Time blocks keyed by weekday; every Monday-Friday list must be non-empty"
+    )
     """
-    Dictionary mapping day names to time blocks
+    Time blocks for every weekday; each weekday list must be non-empty
     """
 
-    classes: list[ClassPattern] = Field(description="List of class patterns")
+    classes: list[ClassPattern] = Field(description="Meeting patterns; at least one pattern must be enabled")
     """
-    List of class patterns
+    Class patterns, with at least one enabled pattern
     """
 
     max_time_gap: PositiveInt = Field(
         default=30,
-        description="Maximum time gap between time slots to determine if they are adjacent",
+        description="Maximum gap in minutes used to determine whether meetings are adjacent",
         json_schema_extra={"example": 30},
         ge=0,
     )
     """
-    Maximum time gap between time slots to determine if they are adjacent (default: 30)
+    Maximum gap in minutes used to determine whether meetings are adjacent (default: 30)
     """
 
     min_time_overlap: PositiveInt = Field(
         default=45,
-        description="Minimum overlap between time slots",
+        description="Minimum clock-time overlap in minutes between meetings on different pattern days",
         json_schema_extra={"example": 45},
         gt=0,
     )
     """
-    Minimum time overlap between time slots (default: 45)
+    Minimum clock-time overlap between meetings on different pattern days (default: 45)
     """
 
     @model_validator(mode="after")
@@ -527,13 +535,23 @@ class CourseConfig(StrictBaseModel):
 
     **Usage:**
     ```python
-    CourseConfig(course_id="CS 101", credits=3, room=[...], lab=[...], conflicts=[], faculty=[])
+    CourseConfig(
+        course_id="CS 101",
+        credits=3,
+        room=["Room 101"],
+        lab=[],
+        conflicts=[],
+        faculty=["Dr. Smith"],
+    )
     ```
     """
 
-    course_id: Course = Field(description="Unique identifier for the course", json_schema_extra={"example": "CS 101"})
+    course_id: Course = Field(
+        description="Base course identifier; repeated values create separately numbered sections",
+        json_schema_extra={"example": "CS 101"},
+    )
     """
-    Unique identifier for the course
+    Base identifier for the course; repeated values create sections in configuration order
     """
 
     credits: PositiveInt = Field(description="Number of credit hours", json_schema_extra={"example": 3})
@@ -552,20 +570,22 @@ class CourseConfig(StrictBaseModel):
 
     lab: list[Lab] = Field(
         default_factory=list,
-        description="List of acceptable lab names",
+        description="Acceptable labs; an empty list means the course has no lab meeting",
         json_schema_extra={"example": ["Lab 101"]},
     )
     """
-    List of acceptable lab names
+    Acceptable labs; empty means the course has no lab meeting
     """
 
-    conflicts: list[Course] = Field(description="List of course IDs that cannot be scheduled simultaneously")
+    conflicts: list[Course] = Field(
+        description="Base course IDs whose sections cannot overlap; an empty list means no declared conflicts"
+    )
     """
-    List of course IDs that cannot be scheduled simultaneously
+    Base course IDs whose sections cannot overlap
     """
 
     faculty: list[Faculty] | None = Field(
-        description="Faculty candidates, or null to derive candidates from faculty course preferences",
+        description=("Non-empty faculty candidates, or null to derive candidates from faculty course-preference keys"),
         json_schema_extra={"example": ["Dr. Smith"]},
     )
     """
@@ -628,11 +648,11 @@ class FacultyConfig(StrictBaseModel):
     """
 
     times: dict[Day, list[TimeRange]] = Field(
-        description="Dictionary mapping day names to time ranges",
+        description="Availability ranges keyed by weekday; omitted days and empty lists mean unavailable",
         json_schema_extra={"example": {"MON": ["10:00-12:00"], "TUE": ["10:00-12:00"]}},
     )
     """
-    Dictionary mapping day names to time ranges
+    Availability ranges by weekday; omitted days and empty lists are unavailable
     """
 
     course_preferences: dict[Course, Preference] = Field(
@@ -944,7 +964,7 @@ class OptimizerFlags(StrEnum):
     **Usage:**
     ```python
     OptimizerFlags.FACULTY_COURSE
-    ["FACULTY_COURSE"]  # accepted in CombinedConfig JSON
+    ["faculty_course"]  # accepted in CombinedConfig JSON
     ```
     """
 
@@ -955,7 +975,7 @@ class OptimizerFlags(StrEnum):
     **Usage:**
     ```python
     OptimizerFlags.FACULTY_ROOM
-    ["FACULTY_ROOM"]  # accepted in CombinedConfig JSON
+    ["faculty_room"]  # accepted in CombinedConfig JSON
     ```
     """
 
@@ -966,51 +986,51 @@ class OptimizerFlags(StrEnum):
     **Usage:**
     ```python
     OptimizerFlags.FACULTY_LAB
-    ["FACULTY_LAB"]  # accepted in CombinedConfig JSON
+    ["faculty_lab"]  # accepted in CombinedConfig JSON
     ```
     """
 
     SAME_ROOM = "same_room"
     """
-    Force same room usage for courses taught by the same faculty
+    Prefer eligible course pairs taught by the same faculty to share a room
 
     **Usage:**
     ```python
     OptimizerFlags.SAME_ROOM
-    ["SAME_ROOM"]  # accepted in CombinedConfig JSON
+    ["same_room"]  # accepted in CombinedConfig JSON
     ```
     """
 
     SAME_LAB = "same_lab"
     """
-    Force same lab usage for courses taught by the same faculty
+    Prefer eligible lab-course pairs taught by the same faculty to share a lab
 
     **Usage:**
     ```python
     OptimizerFlags.SAME_LAB
-    ["SAME_LAB"]  # accepted in CombinedConfig JSON
+    ["same_lab"]  # accepted in CombinedConfig JSON
     ```
     """
 
     PACK_ROOMS = "pack_rooms"
     """
-    Optimize packing of rooms for courses taught
+    Prefer different courses to share a room when any meeting pair is adjacent
 
     **Usage:**
     ```python
     OptimizerFlags.PACK_ROOMS
-    ["PACK_ROOMS"]  # accepted in CombinedConfig JSON
+    ["pack_rooms"]  # accepted in CombinedConfig JSON
     ```
     """
 
     PACK_LABS = "pack_labs"
     """
-    Optimize packing of labs for courses taught
+    Prefer different courses to share a lab at adjacent lab times
 
     **Usage:**
     ```python
     OptimizerFlags.PACK_LABS
-    ["PACK_LABS"]  # accepted in CombinedConfig JSON
+    ["pack_labs"]  # accepted in CombinedConfig JSON
     ```
     """
 

--- a/src/scheduler/json_types.py
+++ b/src/scheduler/json_types.py
@@ -1,8 +1,9 @@
 """
-TypedDict definitions for JSON structures used throughout the scheduler.
+Supplemental TypedDict definitions for serialized schedule rows.
 
-This module provides type-safe definitions for all JSON data structures,
-including configuration, API requests/responses, and schedule outputs.
+Runtime configuration and REST validation are owned by Pydantic models in
+``scheduler.config`` and ``scheduler.server``. These types describe the JSON rows
+emitted by ``JSONWriter`` and are not runtime validators.
 
 **Usage:**
 ```python
@@ -20,26 +21,26 @@ class TimeInstanceJSON(TypedDict):
 
     **Usage:**
     ```python
-    {"day": 0, "start": 480, "duration": 90}
+    {"day": 1, "start": 480, "duration": 90}
     ```
     """
 
     day: int
     """
-    Day enum value (e.g., 0)
+    Day enum value (1 for Monday through 5 for Friday)
 
     **Usage:**
     ```python
-    {"day": 0, "start": 480, "duration": 90}
+    {"day": 1, "start": 480, "duration": 90}
     ```
     """
     start: int
     """
-    Timepoint in minutes (e.g., 0)
+    Start time in minutes since midnight
 
     **Usage:**
     ```python
-    {"day": 0, "start": 480, "duration": 90}
+    {"day": 1, "start": 480, "duration": 90}
     ```
     """
 
@@ -49,7 +50,7 @@ class TimeInstanceJSON(TypedDict):
 
     **Usage:**
     ```python
-    {"day": 0, "start": 480, "duration": 120}
+    {"day": 1, "start": 480, "duration": 120}
     ```
     """
 
@@ -106,11 +107,11 @@ class CourseInstanceJSON(TypedDict):
 
     times: list[TimeInstanceJSON]
     """
-    List of time instances (e.g., `[{"day": 0, "start": 0, "duration": 120}]`)
+    Ordered serialized meeting instances
 
     **Usage:**
     ```python
-    {"course": "CS101.01", "faculty": "Dr. Smith", "times": [{"day": 0, "start": 0, "duration": 120}]}
+    {"course": "CS101.01", "faculty": "Dr. Smith", "times": [{"day": 1, "start": 480, "duration": 120}]}
     ```
     """
 

--- a/src/scheduler/main.py
+++ b/src/scheduler/main.py
@@ -71,7 +71,7 @@ def main(
         OSError: If configuration input or schedule output cannot be accessed.
         json.JSONDecodeError: If the configuration file is not valid JSON.
         ValidationError: If the combined configuration is invalid.
-        SchedulerInitializationError: If solver construction fails.
+        z3.Z3Exception: If Z3 rejects scheduler construction, optimization, or evaluation.
 
     Behavior:
         Logging is configured, configuration is loaded, and explicit limit and

--- a/src/scheduler/models/course.py
+++ b/src/scheduler/models/course.py
@@ -19,7 +19,7 @@ class Course:
 
     course_id: str
     """
-    The unique identifier for the course
+    The base course identifier; repeated configured values are distinguished by section
     """
 
     credits: int

--- a/src/scheduler/models/time_slot.py
+++ b/src/scheduler/models/time_slot.py
@@ -297,7 +297,7 @@ class TimeSlot(BaseModel):
 
     model_config = ConfigDict(extra="forbid", strict=True)
     """
-    Configuration for the model which allows extra fields and is not strict (@private)
+    Configuration that forbids extra fields and requires strict values (@private)
     """
 
     times: list[TimeInstance] = Field(description="The list of time instances in the time slot")
@@ -305,14 +305,20 @@ class TimeSlot(BaseModel):
     The list of time instances in the time slot
     """
 
-    lab_index: int | None = Field(default=None, description="The index of the lab in the time slot")
+    lab_index: int | None = Field(
+        default=None,
+        description="Index of the single lab-marked meeting, or null for a no-lab pattern",
+    )
     """
-    The index of the lab in the time slot
+    Index of the single lab-marked meeting, or null for a no-lab pattern
     """
 
-    max_time_gap: Duration = Field(default=Duration(duration=30), description="The maximum time gap between time slots")
+    max_time_gap: Duration = Field(
+        default=Duration(duration=30),
+        description="Maximum gap used by lecture and lab adjacency checks",
+    )
     """
-    The maximum time gap between time slots
+    Maximum gap used by meeting and lab adjacency checks
     """
 
     def __hash__(self) -> int:

--- a/src/scheduler/problem.py
+++ b/src/scheduler/problem.py
@@ -119,7 +119,7 @@ class SchedulingProblem:
         slot_ranges: Inclusive slot-index range for each credit value.
         course_config_paths: Course display names mapped to source JSON Pointers.
         course_faculty_origins: Course display names mapped to faculty derivation mode.
-        optimizer_flags: Enabled optimization objectives in configured order.
+        optimizer_flags: Enabled optimization objectives as supplied; the solver registers them in fixed order.
         limit: Maximum number of schedules requested by the caller.
     """
 

--- a/src/scheduler/server.py
+++ b/src/scheduler/server.py
@@ -304,7 +304,7 @@ class ScheduleDiagnosisResponse(BaseModel):
 
     Fields:
         schedule_id: Session whose configuration was diagnosed.
-        status: Solver feasibility status such as sat, unsat, or unknown.
+        status: Solver feasibility status: satisfiable, unsatisfiable, or unknown.
         conflicting_constraints: Minimal primary set of conflicting hard rules.
         alternative_conflict_sets: Other independently discovered conflict cores.
         supporting_facts: Relevant non-core facts that explain the conflict.

--- a/src/scheduler/solver.py
+++ b/src/scheduler/solver.py
@@ -1106,7 +1106,7 @@ class SolverEngine:
                 for course in self._courses:
                     if course.course_id in preferences:
                         # Use preference value directly
-                        # (1-5 scale where 5 is strongly prefer, 1 is weakest)
+                        # Preference values use the configured 0-10 scale; zero contributes no objective points.
                         preference_value = preferences[course.course_id]
                         if preference_value == 0:
                             continue

--- a/tests/test_documentation_parity.py
+++ b/tests/test_documentation_parity.py
@@ -1,0 +1,142 @@
+"""Source-driven checks keeping narrative documentation aligned with public behavior."""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from scheduler import CombinedConfig, Scheduler, load_config_from_file
+from scheduler import scheduler as facade_module
+from scheduler.config import (
+    ClassPattern,
+    CourseConfig,
+    FacultyConfig,
+    Meeting,
+    SchedulerConfig,
+    TimeBlock,
+    TimeRange,
+    TimeSlotConfig,
+)
+from scheduler.server import app
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES = ROOT / "fern" / "docs" / "pages"
+
+
+def _page(relative_path: str) -> str:
+    return (PAGES / relative_path).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("model", "pages"),
+    [
+        (TimeBlock, ("configuration/time-slots.mdx",)),
+        (TimeRange, ("configuration/faculty.mdx", "configuration/time-slots.mdx")),
+        (Meeting, ("configuration/time-slots.mdx",)),
+        (ClassPattern, ("configuration/time-slots.mdx",)),
+        (TimeSlotConfig, ("configuration/time-slots.mdx",)),
+        (CourseConfig, ("configuration/courses.mdx",)),
+        (FacultyConfig, ("configuration/faculty.mdx",)),
+        (
+            SchedulerConfig,
+            (
+                "configuration/overview.mdx",
+                "configuration/rooms-labs.mdx",
+                "configuration/courses.mdx",
+                "configuration/faculty.mdx",
+            ),
+        ),
+        (
+            CombinedConfig,
+            (
+                "configuration/overview.mdx",
+                "configuration/limit.mdx",
+                "configuration/optimizer-flags.mdx",
+            ),
+        ),
+    ],
+)
+def test_every_configuration_field_has_narrative_coverage(model, pages: tuple[str, ...]) -> None:
+    """Require each live Pydantic field name in its assigned configuration guide."""
+    narrative = "\n".join(_page(page) for page in pages)
+    missing = [name for name in model.model_fields if f"`{name}`" not in narrative]
+    assert not missing, f"{model.__name__} fields missing from {pages}: {missing}"
+
+
+def test_every_fastapi_route_has_rest_inventory_coverage() -> None:
+    """Require every non-framework application route in the REST integration page."""
+    narrative = _page("rest/quickstart.mdx")
+    framework_routes = {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
+    application_paths = {
+        path
+        for route in app.routes
+        if isinstance((path := getattr(route, "path", None)), str) and path not in framework_routes
+    }
+    missing = sorted(path for path in application_paths if f"`{path}`" not in narrative)
+    assert not missing, f"REST routes missing from endpoint inventory: {missing}"
+
+
+def test_python_guides_cover_facade_methods_and_compatibility_exports() -> None:
+    """Keep documented workflows and legacy public contracts synchronized with the façade."""
+    python_guide = _page("python/overview.mdx")
+    concepts = _page("concepts/diagnostics-auditing.mdx")
+    narrative = python_guide + "\n" + concepts
+
+    public_methods = {
+        name for name, value in inspect.getmembers(Scheduler, predicate=inspect.isfunction) if not name.startswith("_")
+    }
+    missing_methods = sorted(name for name in public_methods if f"`{name}" not in python_guide)
+    missing_exports = sorted(name for name in facade_module.__all__ if f"`{name}`" not in narrative)
+
+    assert not missing_methods, f"Scheduler methods missing from Python guide: {missing_methods}"
+    assert not missing_exports, f"Compatibility exports missing from Python/concepts guides: {missing_exports}"
+
+
+def test_every_api_limit_environment_variable_is_documented() -> None:
+    """Discover server safeguard variables directly from source and require REST coverage."""
+    server_source = (ROOT / "src" / "scheduler" / "server.py").read_text(encoding="utf-8")
+    environment_variables = set(re.findall(r"SCHEDULER_API_[A-Z_]+", server_source))
+    rest_guide = _page("rest/quickstart.mdx")
+    missing = sorted(name for name in environment_variables if f"`{name}`" not in rest_guide)
+    assert not missing, f"API limit variables missing from REST guide: {missing}"
+
+
+def test_canonical_documented_configurations_validate() -> None:
+    """Keep every complete configuration linked as canonical executable input."""
+    overview = _page("configuration/overview.mdx")
+    paths = (ROOT / "tests" / "fixtures" / "minimal_config.json", ROOT / "example.json")
+    for path in paths:
+        assert path.name in overview
+        load_config_from_file(CombinedConfig, path)
+
+
+@pytest.mark.integration
+def test_canonical_minimal_python_workflow_matches_documentation() -> None:
+    """Exercise enumeration, diagnosis, and auditing with the documented minimal input."""
+    config = load_config_from_file(CombinedConfig, ROOT / "tests" / "fixtures" / "minimal_config.json")
+    scheduler = Scheduler(config, solver_timeout_ms=30_000)
+    diagnosis = scheduler.diagnose()
+    schedule = next(scheduler.get_models())
+    audit = scheduler.audit_schedule(schedule)
+
+    assert diagnosis.status == "satisfiable"
+    assert audit.is_valid
+    assert len(schedule) == len(config.config.courses)
+
+
+def test_contributor_docs_reject_monolithic_architecture_claims() -> None:
+    """Prevent the pre-refactor scheduler ownership model from returning."""
+    constraints = _page("dev/constraints.mdx")
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    agent_guide = (ROOT / "AGENT.md").read_text(encoding="utf-8")
+
+    stale_claims = (
+        "Hard scheduling rules are expressed as Z3 boolean formulas in **`src/scheduler/scheduler.py`**",
+        "scheduler.py            # Core scheduling logic and Z3 integration",
+        "src/scheduler/     # Package: config, scheduler (Z3)",
+    )
+    corpus = "\n".join((constraints, contributing, agent_guide))
+    assert not [claim for claim in stale_claims if claim in corpus]
+    assert "`SolverEngine` owns the Z3 context" in constraints
+    assert "`Scheduler` is a stable orchestration façade" in constraints

--- a/tests/test_fern_docs.py
+++ b/tests/test_fern_docs.py
@@ -51,3 +51,21 @@ def test_docs_workflow_generates_and_validates_without_publishing_pull_requests(
     assert "git diff --exit-code -- fern/openapi.json fern/docs/assets/combined-config.schema.json" in workflow
     assert "fern check --warnings" in workflow
     assert "if: github.event_name != 'pull_request'" in workflow
+
+
+def test_docs_workflow_checks_complete_scheduler_reference_surface() -> None:
+    """Require CI coverage for façade methods, helpers, and diagnostic/audit contracts."""
+    workflow = (ROOT / ".github" / "workflows" / "docs.yml").read_text(encoding="utf-8")
+
+    required_reference_terms = (
+        "Scheduler.diagnose",
+        "Scheduler.audit_schedule",
+        "validate_combined_config_data",
+        "load_config_from_file",
+        "ScheduleDiagnosis",
+        "ScheduleAudit",
+        "ConstraintDiagnostic",
+        "CourseInstance",
+    )
+    for term in required_reference_terms:
+        assert term in workflow


### PR DESCRIPTION
## Summary

- add complete scheduling-rules and diagnostics/auditing concept guides
- align configuration, Python, REST, contributor, agent, and repository-skill documentation with current behavior
- correct Fern-exposed source docstrings and regenerate OpenAPI and configuration-schema descriptions
- add source-driven parity tests for configuration fields, FastAPI routes, public exports, API limits, examples, and architecture
- expand CI checks for generated Python reference coverage

## Impact

Documentation now reflects the refactored scheduler engines, exact hard constraints and objectives, diagnostic bounds and completeness semantics, REST lifecycle behavior, and current configuration validation. Runtime APIs and behavior are unchanged.

## Validation

- uv run pytest: 214 passed, 86.53% coverage
- uv run prek run --all-files
- deterministic OpenAPI and configuration-schema regeneration
- Fern Python reference: 21 pages generated
- fern check --warnings: 0 errors; existing redirect-access and automatic contrast-adjustment warnings only
- git diff --check